### PR TITLE
feat(helm): add imagePullSecrets support

### DIFF
--- a/helm/ton-rust-node/CHANGELOG.md
+++ b/helm/ton-rust-node/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 Versions follow the Helm chart release tags (e.g. `helm/v0.3.0`).
 
+## [0.3.1] - 2026-02-18
+
+appVersion: `v0.1.2-mainnet`
+
+### Added
+
+- `imagePullSecrets` — support for private container registries
+
+### Fixed
+
+- Documentation link in NOTES.txt pointed to the old `ton-devops` repository
+
 ## [0.3.0] - 2026-02-13
 
 appVersion: `v0.1.2-mainnet`

--- a/helm/ton-rust-node/Chart.yaml
+++ b/helm/ton-rust-node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ton-rust-node
 description: TON Rust Node deployment
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "v0.1.2-mainnet"
 
 sources:

--- a/helm/ton-rust-node/README.md
+++ b/helm/ton-rust-node/README.md
@@ -173,11 +173,12 @@ When an `existing*Name` is set, the chart does not create that resource — it o
 
 ### Image parameters
 
-| Name               | Description                | Value                          |
-| ------------------ | -------------------------- | ------------------------------ |
-| `image.repository` | Container image repository | `ghcr.io/rsquad/ton-rust-node` |
-| `image.tag`        | Image tag                  | `v0.1.2-mainnet`               |
-| `image.pullPolicy` | Pull policy                | `IfNotPresent`                 |
+| Name               | Description                               | Value                          |
+| ------------------ | ----------------------------------------- | ------------------------------ |
+| `image.repository` | Container image repository                | `ghcr.io/rsquad/ton-rust-node` |
+| `image.tag`        | Image tag                                 | `v0.1.2-mainnet`               |
+| `image.pullPolicy` | Pull policy                               | `IfNotPresent`                 |
+| `imagePullSecrets` | Image pull secrets for private registries | `[]`                           |
 
 ### Init container image parameters
 

--- a/helm/ton-rust-node/templates/statefulset.yaml
+++ b/helm/ton-rust-node/templates/statefulset.yaml
@@ -28,6 +28,10 @@ spec:
       {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ include "ton-rust-node.serviceAccountName" . }}
       {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         fsGroup: 1000
       {{- with .Values.nodeSelector }}

--- a/helm/ton-rust-node/values.yaml
+++ b/helm/ton-rust-node/values.yaml
@@ -19,6 +19,10 @@ image:
   tag: v0.1.2-mainnet
   pullPolicy: IfNotPresent
 
+## @param imagePullSecrets [array] Image pull secrets for private registries
+##
+imagePullSecrets: []
+
 ## @section Init container image parameters
 
 ## @param initImage.repository Init container image repository


### PR DESCRIPTION
appVersion: `v0.1.2-mainnet`

### Added

- `imagePullSecrets` — support for private container registries

### Fixed

- Documentation link in NOTES.txt pointed to the old `ton-devops` repository