### PR TITLE
release/helm/nodectl:v0.1.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.tgz
 .claude/
+AGENTS.md
 external/
 node_modules/
 grafana/ton-node-overview.json

--- a/helm/nodectl/CHANGELOG.md
+++ b/helm/nodectl/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the nodectl Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 Versions follow the Helm chart release tags (e.g. `helm/nodectl/v0.1.0`).
 
+## [0.1.3] - 2026-03-05
+
+appVersion: `v0.2.0`
+
+### Changed
+- Default image updated to nodectl `v0.2.0`
+- Removed `logLevel` and `logFile` chart values — nodectl now manages logging through its own `config log` commands
+- nodectl container now starts with `nodectl service --config=<dataPath>/config.json` (without `--verbose`/`--log-file` args)
+
 ## [0.1.2] - 2026-02-27
 
 appVersion: `v0.1.1`

--- a/helm/nodectl/Chart.yaml
+++ b/helm/nodectl/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: nodectl
 description: TON Node Control Tool — validator elections, voting, and monitoring
 type: application
-version: 0.1.2
-appVersion: "v0.1.1"
+version: 0.1.3
+appVersion: "v0.2.0"
 
 sources:
   - https://github.com/rsquad/ton-rust-node

--- a/helm/nodectl/README.md
+++ b/helm/nodectl/README.md
@@ -110,16 +110,9 @@ The chart sets these environment variables on the nodectl container:
 | Name | Description | Value |
 |------|-------------|-------|
 | `image.repository` | Container image repository | `ghcr.io/rsquad/ton-rust-node/nodectl` |
-| `image.tag` | Image tag | `v0.1.0` |
+| `image.tag` | Image tag | `v0.2.0` |
 | `image.pullPolicy` | Pull policy | `IfNotPresent` |
 | `imagePullSecrets` | Registry pull secrets for private container images | `[]` |
-
-### Container parameters
-
-| Name | Description | Value |
-|------|-------------|-------|
-| `logLevel` | Logging level: trace, debug, info, warn, error | `info` |
-| `logFile` | Path to log file inside the container. Null means stdout only. | `nil` |
 
 ### Port parameters
 
@@ -297,7 +290,7 @@ On first deploy, the init container prepares the PVC:
 | Condition | Command |
 |-----------|---------|
 | `debug.sleep: true` | `sleep infinity` |
-| default | `nodectl --verbose=<logLevel> service --config=<dataPath>/config.json` |
+| default | `nodectl service --config=<dataPath>/config.json` |
 
 ## Documentation
 

--- a/helm/nodectl/docs/maintaining.md
+++ b/helm/nodectl/docs/maintaining.md
@@ -99,7 +99,7 @@ Modifiers:
 |----------|------------|---------|
 | `[object]` | Default is `{}` | `## @param probes [object] Probes config` |
 | `[array]` | Default is `[]` | `## @param extraEnv [array] Extra env vars` |
-| `[nullable]` | Default is `null` | `## @param logFile [nullable] Log file path` |
+| `[nullable]` | Default is `null` | `## @param storage.storageClassName [nullable] Storage class` |
 | `[default: text]` | Custom display text | `## @param config [default: ""] Config JSON` |
 
 Exclude a parameter with `## @skip`:

--- a/helm/nodectl/docs/setup.md
+++ b/helm/nodectl/docs/setup.md
@@ -381,8 +381,6 @@ helm upgrade my-nodectl oci://ghcr.io/rsquad/ton-rust-node/helm/nodectl \
   --set debug.sleep=true
 ```
 
-### Verbose logging
+### Logging
 
-```yaml
-logLevel: debug
-```
+nodectl uses its built-in defaults when started by this chart. Use `kubectl logs` for runtime diagnostics.

--- a/helm/nodectl/templates/deployment.yaml
+++ b/helm/nodectl/templates/deployment.yaml
@@ -96,10 +96,6 @@ spec:
           {{- else }}
           command: ["nodectl"]
           args:
-            - "--verbose={{ .Values.logLevel }}"
-            {{- if .Values.logFile }}
-            - "--log-file={{ .Values.logFile }}"
-            {{- end }}
             - "service"
             - "--config={{ .Values.dataPath }}/config.json"
           {{- end }}

--- a/helm/nodectl/values.yaml
+++ b/helm/nodectl/values.yaml
@@ -12,22 +12,12 @@ replicas: 1
 ##
 image:
   repository: ghcr.io/rsquad/ton-rust-node/nodectl
-  tag: "v0.1.1"
+  tag: "v0.2.0"
   pullPolicy: IfNotPresent
 
 ## @param imagePullSecrets [array] Registry pull secrets for private container images
 ##
 imagePullSecrets: []
-
-## @section Container parameters
-
-## @param logLevel Logging level: trace, debug, info, warn, error
-##
-logLevel: info
-
-## @param logFile [nullable] Path to log file inside the container. Null means stdout only.
-##
-logFile: null
 
 ## @section Port parameters
 


### PR DESCRIPTION
appVersion: `v0.2.0`

### Changed
- Default image updated to nodectl `v0.2.0`
- Removed `logLevel` and `logFile` chart values — nodectl now manages logging through its own `config log` commands
- nodectl container now starts with `nodectl service --config=<dataPath>/config.json` (without `--verbose`/`--log-file` args)