### PR TITLE
release/helm/node:v0.4.2

### DIFF
--- a/helm/ton-rust-node/CHANGELOG.md
+++ b/helm/ton-rust-node/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 Versions follow the Helm chart release tags (e.g. `helm/v0.3.0`).
 
+## [0.4.2] - 2026-03-18
+
+appVersion: `v0.3.0`
+
+### Added
+
+- `ports.simplex` — simplex consensus port (UDP). Disabled by default; only needed for validators after switching to simplex consensus. Set to `true` (adnl + 1000) or an explicit port number to enable. Includes per-replica Service, hostPort, and NetworkPolicy support
+
+### Fixed
+
+- Vault URL example in values.yaml used `&` separator instead of `?`
+
 ## [0.4.1] - 2026-03-12
 
 appVersion: `v0.3.0`

--- a/helm/ton-rust-node/Chart.yaml
+++ b/helm/ton-rust-node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: node
 description: TON Rust Node deployment
 type: application
-version: 0.4.1
+version: 0.4.2
 appVersion: "v0.3.0"
 
 sources:

--- a/helm/ton-rust-node/README.md
+++ b/helm/ton-rust-node/README.md
@@ -173,12 +173,12 @@ When an `existing*Name` is set, the chart does not create that resource — it o
 
 ### Image parameters
 
-| Name               | Description                               | Value                          |
-| ------------------ | ----------------------------------------- | ------------------------------ |
+| Name               | Description                               | Value                               |
+| ------------------ | ----------------------------------------- | ----------------------------------- |
 | `image.repository` | Container image repository                | `ghcr.io/rsquad/ton-rust-node/node` |
-| `image.tag`        | Image tag                                 | `v0.1.2-mainnet`               |
-| `image.pullPolicy` | Pull policy                               | `IfNotPresent`                 |
-| `imagePullSecrets` | Image pull secrets for private registries | `[]`                           |
+| `image.tag`        | Image tag                                 | `v0.3.0`                            |
+| `image.pullPolicy` | Pull policy                               | `IfNotPresent`                      |
+| `imagePullSecrets` | Image pull secrets for private registries | `[]`                                |
 
 ### Init container image parameters
 
@@ -218,35 +218,36 @@ When an `existing*Name` is set, the chart does not create that resource — it o
 
 ### Storage parameters
 
-| Name                            | Description                                                    | Value        |
-| ------------------------------- | -------------------------------------------------------------- | ------------ |
-| `storage.main.size`             | Main volume size                                               | `1Gi`        |
-| `storage.main.storageClassName` | Storage class for main volume                                  | `local-path` |
-| `storage.main.resourcePolicy`   | Value for the `helm.sh/resource-policy` annotation. Set to `keep` to prevent PVC deletion on `helm uninstall`. Set to empty string to omit. | `keep` |
-| `storage.main.annotations`      | Extra annotations for the main PVC                             | `{}`         |
-| `storage.db.size`               | Database volume size (hundreds of GB for mainnet)              | `1Ti`        |
-| `storage.db.storageClassName`   | Storage class for database volume                              | `local-path` |
-| `storage.db.resourcePolicy`     | Value for the `helm.sh/resource-policy` annotation on the db PVC | `""`       |
-| `storage.db.annotations`        | Extra annotations for the db PVC                               | `{}`         |
-| `storage.logs.enabled`          | Create a PVC for logs. Set to false if you log to stdout only. | `true`       |
-| `storage.logs.size`             | Logs volume size                                               | `150Gi`      |
-| `storage.logs.storageClassName` | Storage class for logs volume                                  | `local-path` |
-| `storage.logs.resourcePolicy`   | Value for the `helm.sh/resource-policy` annotation on the logs PVC | `""`     |
-| `storage.logs.annotations`      | Extra annotations for the logs PVC                             | `{}`         |
-| `storage.keys.size`             | Keys volume size                                               | `1Gi`        |
-| `storage.keys.storageClassName` | Storage class for keys volume                                  | `local-path` |
-| `storage.keys.resourcePolicy`   | Value for the `helm.sh/resource-policy` annotation on the keys PVC | `keep`   |
-| `storage.keys.annotations`      | Extra annotations for the keys PVC                             | `{}`         |
+| Name                            | Description                                                                                                                                 | Value        |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| `storage.main.size`             | Main volume size                                                                                                                            | `1Gi`        |
+| `storage.main.storageClassName` | Storage class for main volume                                                                                                               | `local-path` |
+| `storage.main.resourcePolicy`   | Value for the `helm.sh/resource-policy` annotation. Set to `keep` to prevent PVC deletion on `helm uninstall`. Set to empty string to omit. | `keep`       |
+| `storage.main.annotations`      | Extra annotations for the main PVC                                                                                                          | `{}`         |
+| `storage.db.size`               | Database volume size (hundreds of GB for mainnet)                                                                                           | `1Ti`        |
+| `storage.db.storageClassName`   | Storage class for database volume                                                                                                           | `local-path` |
+| `storage.db.resourcePolicy`     | Value for the `helm.sh/resource-policy` annotation on the db PVC                                                                            | `""`         |
+| `storage.db.annotations`        | Extra annotations for the db PVC                                                                                                            | `{}`         |
+| `storage.logs.enabled`          | Create a PVC for logs. Set to false if you log to stdout only.                                                                              | `true`       |
+| `storage.logs.size`             | Logs volume size                                                                                                                            | `150Gi`      |
+| `storage.logs.storageClassName` | Storage class for logs volume                                                                                                               | `local-path` |
+| `storage.logs.resourcePolicy`   | Value for the `helm.sh/resource-policy` annotation on the logs PVC                                                                          | `""`         |
+| `storage.logs.annotations`      | Extra annotations for the logs PVC                                                                                                          | `{}`         |
+| `storage.keys.size`             | Keys volume size                                                                                                                            | `1Gi`        |
+| `storage.keys.storageClassName` | Storage class for keys volume                                                                                                               | `local-path` |
+| `storage.keys.resourcePolicy`   | Value for the `helm.sh/resource-policy` annotation on the keys PVC                                                                          | `keep`       |
+| `storage.keys.annotations`      | Extra annotations for the keys PVC                                                                                                          | `{}`         |
 
 ### Port parameters
 
-| Name               | Description                                                                        | Value   |
-| ------------------ | ---------------------------------------------------------------------------------- | ------- |
-| `ports.adnl`       | ADNL port (UDP)                                                                    | `30303` |
-| `ports.control`    | Control port (TCP). Set to null to disable.                                        | `50000` |
-| `ports.liteserver` | Liteserver port (TCP). Set to enable.                                              | `nil`   |
-| `ports.jsonRpc`    | JSON-RPC port (TCP). Set to enable.                                                | `nil`   |
-| `ports.metrics`    | Metrics/probes HTTP port (TCP). Serves /metrics, /healthz, /readyz. Set to enable. | `nil`   |
+| Name               | Description                                                                                                                                                                 | Value   |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `ports.adnl`       | ADNL port (UDP)                                                                                                                                                             | `30303` |
+| `ports.simplex`    | Simplex consensus port (UDP). Only needed for validators after switching to simplex consensus. false/null = disabled (default), true = adnl + 1000, number = explicit port. | `false` |
+| `ports.control`    | Control port (TCP). Set to null to disable.                                                                                                                                 | `50000` |
+| `ports.liteserver` | Liteserver port (TCP). Set to enable.                                                                                                                                       | `nil`   |
+| `ports.jsonRpc`    | JSON-RPC port (TCP). Set to enable.                                                                                                                                         | `nil`   |
+| `ports.metrics`    | Metrics/probes HTTP port (TCP). Serves /metrics, /healthz, /readyz. Set to enable.                                                                                          | `nil`   |
 
 ### Service parameters
 
@@ -254,13 +255,20 @@ When an `existing*Name` is set, the chart does not create that resource — it o
 | ------------------------------------------- | --------------------------------------------------------------- | -------------- |
 | `services.adnl.type`                        | ADNL service type                                               | `LoadBalancer` |
 | `services.adnl.externalTrafficPolicy`       | ADNL service traffic policy                                     | `Local`        |
+| `services.adnl.labels`                      | Extra labels applied to all ADNL per-replica services           | `{}`           |
 | `services.adnl.annotations`                 | Annotations applied to all ADNL per-replica services            | `{}`           |
 | `services.adnl.perReplica`                  | Per-replica ADNL service overrides (list index = replica index) | `[]`           |
+| `services.simplex.type`                     | Simplex service type                                            | `LoadBalancer` |
+| `services.simplex.externalTrafficPolicy`    | Simplex service traffic policy                                  | `Local`        |
+| `services.simplex.labels`                   | Extra labels for simplex services                               | `{}`           |
 | `services.control.type`                     | Control service type                                            | `ClusterIP`    |
+| `services.control.labels`                   | Extra labels for control services                               | `{}`           |
 | `services.liteserver.type`                  | Liteserver service type                                         | `LoadBalancer` |
 | `services.liteserver.externalTrafficPolicy` | Liteserver service traffic policy                               | `Local`        |
+| `services.liteserver.labels`                | Extra labels for liteserver services                            | `{}`           |
 | `services.jsonRpc.type`                     | JSON-RPC service type                                           | `LoadBalancer` |
 | `services.jsonRpc.externalTrafficPolicy`    | JSON-RPC service traffic policy                                 | `Local`        |
+| `services.jsonRpc.labels`                   | Extra labels for JSON-RPC services                              | `{}`           |
 
 ### Configuration parameters
 
@@ -297,12 +305,21 @@ When an `existing*Name` is set, the chart does not create that resource — it o
 | `extraEnv`     | Additional environment variables for the main node container. Supports Downward API, ConfigMap/Secret refs, etc.             | `[]`  |
 | `extraEnvFrom` | Additional envFrom sources for the main node container. Inject all keys from a Secret or ConfigMap as environment variables. | `[]`  |
 
+### Vault parameters
+
+| Name               | Description                                                                           | Value       |
+| ------------------ | ------------------------------------------------------------------------------------- | ----------- |
+| `vault.url`        | Vault URL (plain text). Example: `file:///keys/vault.json?master_key=<hex>`           | `""`        |
+| `vault.secretName` | Name of an existing Secret containing the vault URL. Takes precedence over vault.url. | `""`        |
+| `vault.secretKey`  | Key inside the Secret that holds the vault URL.                                       | `VAULT_URL` |
+
 ### Networking parameters
 
 | Name                  | Description                                                                                                                                                                                            | Value   |
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
 | `hostNetwork`         | Bind pods directly to the host network. The pod gets the node's IP with zero NAT overhead. Requires one pod per node — use nodeSelector or podAntiAffinity to spread replicas. See docs/networking.md. | `false` |
 | `hostPort.adnl`       | Expose the ADNL port on the host IP via hostPort                                                                                                                                                       | `false` |
+| `hostPort.simplex`    | Expose the simplex port on the host IP via hostPort                                                                                                                                                    | `false` |
 | `hostPort.control`    | Expose the control port on the host IP via hostPort                                                                                                                                                    | `false` |
 | `hostPort.liteserver` | Expose the liteserver port on the host IP via hostPort                                                                                                                                                 | `false` |
 | `hostPort.jsonRpc`    | Expose the JSON-RPC port on the host IP via hostPort                                                                                                                                                   | `false` |
@@ -310,11 +327,20 @@ When an `existing*Name` is set, the chart does not create that resource — it o
 
 ### NetworkPolicy parameters
 
-| Name                         | Description                                                                                                                                                                       | Value   |
-| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `networkPolicy.enabled`      | Create a NetworkPolicy. ADNL is always allowed from 0.0.0.0/0. TCP ports (control, liteserver, jsonRpc, metrics) get rules automatically when enabled — restrict with allowCIDRs. | `false` |
-| `networkPolicy.allowCIDRs`   | Source CIDRs for TCP port rules (control, liteserver, jsonRpc, metrics). If empty, traffic is not restricted by source.                                                           | `[]`    |
-| `networkPolicy.extraIngress` | Additional raw ingress rules appended to the policy.                                                                                                                              | `[]`    |
+| Name                                 | Description                                                                                                     | Value   |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------------------- | ------- |
+| `networkPolicy.enabled`              | Create a NetworkPolicy                                                                                          | `false` |
+| `networkPolicy.adnl.allowFrom`       | ADNL ingress sources. Default allows all traffic (0.0.0.0/0). Each entry is a raw NetworkPolicy `from` item.    | `[]`    |
+| `networkPolicy.simplex.allowFrom`    | Simplex ingress sources. Default allows all traffic (0.0.0.0/0). Each entry is a raw NetworkPolicy `from` item. | `[]`    |
+| `networkPolicy.control.enabled`      | Create an ingress rule for the control port                                                                     | `false` |
+| `networkPolicy.control.allowFrom`    | Control port ingress sources. If empty, allows all.                                                             | `[]`    |
+| `networkPolicy.liteserver.enabled`   | Create an ingress rule for the liteserver port                                                                  | `false` |
+| `networkPolicy.liteserver.allowFrom` | Liteserver port ingress sources. If empty, allows all.                                                          | `[]`    |
+| `networkPolicy.jsonRpc.enabled`      | Create an ingress rule for the JSON-RPC port                                                                    | `false` |
+| `networkPolicy.jsonRpc.allowFrom`    | JSON-RPC port ingress sources. If empty, allows all.                                                            | `[]`    |
+| `networkPolicy.metrics.enabled`      | Create an ingress rule for the metrics port                                                                     | `false` |
+| `networkPolicy.metrics.allowFrom`    | Metrics port ingress sources. If empty, allows all.                                                             | `[]`    |
+| `networkPolicy.extraIngress`         | Additional raw ingress rules appended to the policy.                                                            | `[]`    |
 
 ### ServiceAccount parameters
 

--- a/helm/ton-rust-node/docs/networking.md
+++ b/helm/ton-rust-node/docs/networking.md
@@ -16,11 +16,12 @@ A TON node needs a stable, publicly reachable IP address — other nodes connect
 
 ## Ports and services
 
-The chart manages five ports. Each port is optional (set to `null` to disable) except ADNL which is always enabled.
+The chart manages six ports. Each port is optional (set to `null` to disable) except ADNL which is always enabled.
 
 | Port | Protocol | Default | Purpose |
 |------|----------|---------|---------|
 | `ports.adnl` | UDP | `30303` | Peer-to-peer protocol. Must be publicly reachable. |
+| `ports.simplex` | UDP | `false` | Simplex consensus protocol. Only needed for validators after switching to simplex consensus. `true` = adnl + 1000, or set an explicit port number. |
 | `ports.control` | TCP | `50000` | Node management (stop, restart, elections). Recommended to keep internal. |
 | `ports.liteserver` | TCP | `null` | Liteserver API for external consumers. |
 | `ports.jsonRpc` | TCP | `null` | JSON-RPC API for external consumers. |
@@ -33,6 +34,7 @@ Each enabled port gets its own per-replica Kubernetes Service. This allows indep
 | Port | Service name | Default type | Rationale |
 |------|-------------|-------------|-----------|
 | ADNL | `<release>-<i>` | LoadBalancer | Must be publicly reachable for P2P |
+| simplex | `<release>-<i>-simplex` | LoadBalancer | Simplex consensus — must be publicly reachable for validators |
 | control | `<release>-<i>-control` | ClusterIP | Node management — recommended to keep internal |
 | liteserver | `<release>-<i>-liteserver` | LoadBalancer | Serves external API consumers |
 | jsonRpc | `<release>-<i>-jsonrpc` | LoadBalancer | Serves external API consumers |
@@ -147,6 +149,7 @@ Each port can be independently enabled:
 ```yaml
 hostPort:
   adnl: true
+  simplex: false
   control: false
   liteserver: false
   jsonRpc: false

--- a/helm/ton-rust-node/templates/_helpers.tpl
+++ b/helm/ton-rust-node/templates/_helpers.tpl
@@ -153,6 +153,22 @@ Usage: {{ include "node.serviceLabels" (dict "svcConfig" .Values.services.adnl "
 {{- end }}
 
 {{/*
+Simplex port resolver.
+  null / false → disabled (empty string)
+  true         → adnl + 1000
+  <number>     → that number
+*/}}
+{{- define "node.simplexPort" -}}
+{{- if kindIs "bool" .Values.ports.simplex -}}
+  {{- if .Values.ports.simplex -}}
+    {{- add .Values.ports.adnl 1000 -}}
+  {{- end -}}
+{{- else if .Values.ports.simplex -}}
+  {{- .Values.ports.simplex -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Boolean helper: whether vault is configured.
 */}}
 {{- define "node.hasVault" -}}

--- a/helm/ton-rust-node/templates/networkpolicy.yaml
+++ b/helm/ton-rust-node/templates/networkpolicy.yaml
@@ -22,6 +22,18 @@ spec:
         - ipBlock:
             cidr: 0.0.0.0/0
         {{- end }}
+    {{- with (include "node.simplexPort" .) }}
+    - ports:
+        - port: {{ . }}
+          protocol: UDP
+      from:
+        {{- if $.Values.networkPolicy.simplex.allowFrom }}
+        {{- toYaml $.Values.networkPolicy.simplex.allowFrom | nindent 8 }}
+        {{- else }}
+        - ipBlock:
+            cidr: 0.0.0.0/0
+        {{- end }}
+    {{- end }}
     {{- if and .Values.ports.control .Values.networkPolicy.control.enabled }}
     - ports:
         - port: {{ .Values.ports.control }}

--- a/helm/ton-rust-node/templates/services.yaml
+++ b/helm/ton-rust-node/templates/services.yaml
@@ -24,6 +24,34 @@ spec:
       port: {{ $root.Values.ports.adnl }}
       protocol: UDP
 
+{{- $simplexPort := (include "node.simplexPort" $root) }}
+{{- if $simplexPort }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullname }}-{{ $i }}-simplex
+  labels:
+    {{- include "node.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: simplex
+    {{- with $root.Values.services.simplex.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- include "node.serviceAnnotations" (dict "svcConfig" $root.Values.services.simplex "replicaIndex" $i) | nindent 2 }}
+spec:
+  type: {{ $root.Values.services.simplex.type }}
+  {{- if ne $root.Values.services.simplex.type "ClusterIP" }}
+  externalTrafficPolicy: {{ $root.Values.services.simplex.externalTrafficPolicy | default "Local" }}
+  {{- end }}
+  selector:
+    {{- include "node.selectorLabels" $root | nindent 4 }}
+    statefulset.kubernetes.io/pod-name: {{ $fullname }}-{{ $i }}
+  ports:
+    - name: simplex
+      port: {{ $simplexPort }}
+      protocol: UDP
+{{- end }}
+
 {{- if $root.Values.ports.control }}
 ---
 apiVersion: v1

--- a/helm/ton-rust-node/templates/statefulset.yaml
+++ b/helm/ton-rust-node/templates/statefulset.yaml
@@ -126,6 +126,14 @@ spec:
               {{- if .Values.hostPort.adnl }}
               hostPort: {{ .Values.ports.adnl }}
               {{- end }}
+            {{- with (include "node.simplexPort" .) }}
+            - name: simplex
+              containerPort: {{ . }}
+              protocol: UDP
+              {{- if $.Values.hostPort.simplex }}
+              hostPort: {{ . }}
+              {{- end }}
+            {{- end }}
             {{- if .Values.ports.control }}
             - name: control
               containerPort: {{ .Values.ports.control }}

--- a/helm/ton-rust-node/values.yaml
+++ b/helm/ton-rust-node/values.yaml
@@ -133,6 +133,7 @@ storage:
 ## @section Port parameters
 
 ## @param ports.adnl ADNL port (UDP)
+## @param ports.simplex [nullable] Simplex consensus port (UDP). Only needed for validators after switching to simplex consensus. false/null = disabled (default), true = adnl + 1000, number = explicit port.
 ## @param ports.control Control port (TCP). Set to null to disable.
 ## @param ports.liteserver [nullable] Liteserver port (TCP). Set to enable.
 ## @param ports.jsonRpc [nullable] JSON-RPC port (TCP). Set to enable.
@@ -140,6 +141,7 @@ storage:
 ##
 ports:
   adnl: 30303
+  simplex: false
   control: 50000
   liteserver: null
   jsonRpc: null
@@ -155,6 +157,10 @@ ports:
 ## @param services.adnl.labels [object] Extra labels applied to all ADNL per-replica services
 ## @param services.adnl.annotations [object] Annotations applied to all ADNL per-replica services
 ## @param services.adnl.perReplica [array] Per-replica ADNL service overrides (list index = replica index)
+##
+## @param services.simplex.type Simplex service type
+## @param services.simplex.externalTrafficPolicy Simplex service traffic policy
+## @param services.simplex.labels [object] Extra labels for simplex services
 ##
 ## @param services.control.type Control service type
 ## @param services.control.labels [object] Extra labels for control services
@@ -174,6 +180,10 @@ services:
     labels: {}
     annotations: {}
     perReplica: []
+  simplex:
+    type: LoadBalancer
+    externalTrafficPolicy: Local
+    labels: {}
   control:
     type: ClusterIP
     labels: {}
@@ -294,7 +304,7 @@ extraEnvFrom: []
 ## Provide either vault.url (plain text) or vault.secretName (recommended).
 ## See docs/vault.md for details.
 
-## @param vault.url Vault URL (plain text). Example: `file:///keys/vault.json&master_key=<hex>`
+## @param vault.url Vault URL (plain text). Example: `file:///keys/vault.json?master_key=<hex>`
 ## @param vault.secretName Name of an existing Secret containing the vault URL. Takes precedence over vault.url.
 ## @param vault.secretKey Key inside the Secret that holds the vault URL.
 ##
@@ -310,6 +320,7 @@ vault:
 hostNetwork: false
 
 ## @param hostPort.adnl Expose the ADNL port on the host IP via hostPort
+## @param hostPort.simplex Expose the simplex port on the host IP via hostPort
 ## @param hostPort.control Expose the control port on the host IP via hostPort
 ## @param hostPort.liteserver Expose the liteserver port on the host IP via hostPort
 ## @param hostPort.jsonRpc Expose the JSON-RPC port on the host IP via hostPort
@@ -317,6 +328,7 @@ hostNetwork: false
 ##
 hostPort:
   adnl: false
+  simplex: false
   control: false
   liteserver: false
   jsonRpc: false
@@ -339,6 +351,7 @@ hostPort:
 
 ## @param networkPolicy.enabled Create a NetworkPolicy
 ## @param networkPolicy.adnl.allowFrom [array] ADNL ingress sources. Default allows all traffic (0.0.0.0/0). Each entry is a raw NetworkPolicy `from` item.
+## @param networkPolicy.simplex.allowFrom [array] Simplex ingress sources. Default allows all traffic (0.0.0.0/0). Each entry is a raw NetworkPolicy `from` item.
 ## @param networkPolicy.control.enabled Create an ingress rule for the control port
 ## @param networkPolicy.control.allowFrom [array] Control port ingress sources. If empty, allows all.
 ## @param networkPolicy.liteserver.enabled Create an ingress rule for the liteserver port
@@ -352,6 +365,8 @@ hostPort:
 networkPolicy:
   enabled: false
   adnl:
+    allowFrom: []
+  simplex:
     allowFrom: []
   control:
     enabled: false


### PR DESCRIPTION
appVersion: `v0.3.0`

### Added

- `ports.simplex` — simplex consensus port (UDP). Disabled by default; only needed for validators after switching to simplex consensus. Set to `true` (adnl + 1000) or an explicit port number to enable. Includes per-replica Service, hostPort, and NetworkPolicy support

### Fixed

- Vault URL example in values.yaml used `&` separator instead of `?`