### PR TITLE
release/helm/nodectl:v0.1.4

### DIFF
--- a/helm/nodectl/CHANGELOG.md
+++ b/helm/nodectl/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the nodectl Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 Versions follow the Helm chart release tags (e.g. `helm/nodectl/v0.1.0`).
 
+## [0.1.4] - 2026-03-19
+
+appVersion: `v0.2.1`
+
+### Changed
+
+- Default image updated to nodectl `v0.2.1`
+
+### Fixed
+
+- Vault URL examples used `&` separator instead of `?`
+
 ## [0.1.3] - 2026-03-05
 
 appVersion: `v0.2.0`

--- a/helm/nodectl/Chart.yaml
+++ b/helm/nodectl/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: nodectl
 description: TON Node Control Tool — validator elections, voting, and monitoring
 type: application
-version: 0.1.3
-appVersion: "v0.2.0"
+version: 0.1.4
+appVersion: "v0.2.1"
 
 sources:
   - https://github.com/rsquad/ton-rust-node

--- a/helm/nodectl/README.md
+++ b/helm/nodectl/README.md
@@ -70,7 +70,7 @@ Vault stores private keys (wallet keys, control client keys). Currently only the
 
 | Backend | URL format | Use case |
 |---------|-----------|----------|
-| File-based | `file:///nodectl/data/vault.json&master_key=<hex>` | All setups |
+| File-based | `file:///nodectl/data/vault.json?master_key=<hex>` | All setups |
 
 Vault is configured via the **`VAULT_URL` environment variable**, not in `config.json`. The Helm chart passes this from a K8s Secret or plain value.
 
@@ -110,7 +110,7 @@ The chart sets these environment variables on the nodectl container:
 | Name               | Description                                        | Value                                  |
 | ------------------ | -------------------------------------------------- | -------------------------------------- |
 | `image.repository` | Container image repository                         | `ghcr.io/rsquad/ton-rust-node/nodectl` |
-| `image.tag`        | Image tag                                          | `v0.2.0`                               |
+| `image.tag`        | Image tag                                          | `v0.2.1`                               |
 | `image.pullPolicy` | Pull policy                                        | `IfNotPresent`                         |
 | `imagePullSecrets` | Registry pull secrets for private container images | `[]`                                   |
 
@@ -147,7 +147,7 @@ The chart sets these environment variables on the nodectl container:
 
 | Name               | Description                                                                                                                               | Value       |
 | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| `vault.url`        | Vault URL (plain text). Examples: `file:///nodectl/data/vault.json&master_key=<hex>`, `hashicorp://<addr>?api_key=<token>&namespace=<ns>` | `""`        |
+| `vault.url`        | Vault URL (plain text). Examples: `file:///nodectl/data/vault.json?master_key=<hex>`, `hashicorp://<addr>?api_key=<token>&namespace=<ns>` | `""`        |
 | `vault.secretName` | Name of an existing Secret containing the vault URL. Takes precedence over vault.url.                                                     | `""`        |
 | `vault.secretKey`  | Key inside the Secret that holds the vault URL.                                                                                           | `VAULT_URL` |
 

--- a/helm/nodectl/docs/setup.md
+++ b/helm/nodectl/docs/setup.md
@@ -47,7 +47,7 @@ See [Secrets Vault](../../ton-rust-node/docs/vault.md) for vault setup, URL form
 
 ```bash
 kubectl create secret generic nodectl-vault \
-  --from-literal=VAULT_URL="file:///nodectl/data/vault.json&master_key=$(openssl rand -hex 32)"
+  --from-literal=VAULT_URL="file:///nodectl/data/vault.json?master_key=$(openssl rand -hex 32)"
 ```
 
 ### Install the chart
@@ -388,7 +388,7 @@ kubectl create secret generic nodectl-config \
 
 # Recreate the vault secret with the same master key as the original
 kubectl create secret generic nodectl-vault \
-  --from-literal=VAULT_URL="file:///nodectl/data/vault.json&master_key=<ORIGINAL_MASTER_KEY>"
+  --from-literal=VAULT_URL="file:///nodectl/data/vault.json?master_key=<ORIGINAL_MASTER_KEY>"
 ```
 
 ### 3. Deploy with initConfig

--- a/helm/nodectl/values.yaml
+++ b/helm/nodectl/values.yaml
@@ -12,7 +12,7 @@ replicas: 1
 ##
 image:
   repository: ghcr.io/rsquad/ton-rust-node/nodectl
-  tag: "v0.2.0"
+  tag: "v0.2.1"
   pullPolicy: IfNotPresent
 
 ## @param imagePullSecrets [array] Registry pull secrets for private container images
@@ -62,7 +62,7 @@ dataPath: /nodectl/data
 ## Provide either vault.url (plain text) or vault.secretName (recommended).
 ## See ../../ton-rust-node/docs/vault.md for details.
 
-## @param vault.url Vault URL (plain text). Examples: `file:///nodectl/data/vault.json&master_key=<hex>`, `hashicorp://<addr>?api_key=<token>&namespace=<ns>`
+## @param vault.url Vault URL (plain text). Examples: `file:///nodectl/data/vault.json?master_key=<hex>`, `hashicorp://<addr>?api_key=<token>&namespace=<ns>`
 ## @param vault.secretName Name of an existing Secret containing the vault URL. Takes precedence over vault.url.
 ## @param vault.secretKey Key inside the Secret that holds the vault URL.
 ##


### PR DESCRIPTION
appVersion: `v0.2.1`

### Changed

- Default image updated to nodectl `v0.2.1`

### Fixed

- Vault URL examples used `&` separator instead of `?`