### PR TITLE
release/helm/node:v0.4.5

### DIFF
--- a/helm/ton-rust-node/CHANGELOG.md
+++ b/helm/ton-rust-node/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 Versions follow the Helm chart release tags (e.g. `helm/v0.3.0`).
 
+## [0.4.5] - 2026-04-05
+
+appVersion: `v0.4.0`
+
+### Changed
+
+- Default image tag and appVersion updated to `v0.4.0`
+
 ## [0.4.4] - 2026-04-02
 
 appVersion: `v0.3.0`

--- a/helm/ton-rust-node/Chart.yaml
+++ b/helm/ton-rust-node/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: node
 description: TON Rust Node deployment
 type: application
-version: 0.4.4
-appVersion: "v0.3.0"
+version: 0.4.5
+appVersion: "v0.4.0"
 
 sources:
   - https://github.com/rsquad/ton-rust-node

--- a/helm/ton-rust-node/values.yaml
+++ b/helm/ton-rust-node/values.yaml
@@ -16,7 +16,7 @@ command: []
 ##
 image:
   repository: ghcr.io/rsquad/ton-rust-node/node
-  tag: v0.3.0
+  tag: v0.4.0
   pullPolicy: IfNotPresent
 
 ## @param imagePullSecrets [array] Image pull secrets for private registries


### PR DESCRIPTION
### Changed

- Default image tag and appVersion updated to `v0.4.0`