### PR TITLE
fix:master_wallet can't be deleted or duplicated

### DIFF
--- a/src/node-control/commands/src/commands/nodectl/config_wallet_cmd.rs
+++ b/src/node-control/commands/src/commands/nodectl/config_wallet_cmd.rs
@@ -41,6 +41,9 @@ const NPOOL_COMPUTE_FEE: u64 = 200_000_000;
 /// Gas fee consumed by wallet to send message to nominator pool.
 const WALLET_COMPUTE_FEE: u64 = 100_000_000;
 
+/// Name shown for `master_wallet` in `config wallet ls` and accepted by `get_wallet_config`.
+const MASTER_WALLET_RESERVED_NAME: &str = "master_wallet";
+
 #[derive(clap::Args, Clone)]
 #[command(about = "Manage wallets in the configuration")]
 pub struct WalletCmd {
@@ -138,7 +141,7 @@ impl WalletCmd {
 
 impl WalletAddCmd {
     pub async fn run(&self, path: &Path) -> anyhow::Result<()> {
-        if self.name == "master_wallet" {
+        if self.name == MASTER_WALLET_RESERVED_NAME {
             anyhow::bail!("'master_wallet' is a reserved name");
         }
 
@@ -196,7 +199,7 @@ impl WalletLsCmd {
         let mut all_wallets: Vec<(&str, &WalletConfig)> =
             config.wallets.iter().map(|(k, v)| (k.as_str(), v)).collect();
         if let Some(mw) = config.master_wallet.as_ref() {
-            all_wallets.push(("master_wallet", mw));
+            all_wallets.push((MASTER_WALLET_RESERVED_NAME, mw));
         }
 
         if all_wallets.is_empty() {
@@ -326,6 +329,10 @@ async fn print_wallets_table(
 
 impl WalletRmCmd {
     pub async fn run(&self, path: &Path) -> anyhow::Result<()> {
+        if self.name == MASTER_WALLET_RESERVED_NAME {
+            anyhow::bail!("The master wallet cannot be removed");
+        }
+
         let mut config = AppConfig::load(path)?;
 
         if !config.wallets.contains_key(&self.name) {

--- a/src/node-control/commands/src/commands/nodectl/config_wallet_cmd.rs
+++ b/src/node-control/commands/src/commands/nodectl/config_wallet_cmd.rs
@@ -9,9 +9,10 @@
 use crate::commands::nodectl::{
     output_format::OutputFormat,
     utils::{
-        SEND_TIMEOUT, check_ton_api_connection, get_wallet_config, load_config_vault,
-        load_config_vault_rpc_client, make_wallet, save_config, wait_for_seqno_change,
-        wallet_address, wallet_info, warn_missing_secret, warn_ton_api_unavailable,
+        MASTER_WALLET_RESERVED_NAME, SEND_TIMEOUT, check_ton_api_connection, get_wallet_config,
+        load_config_vault, load_config_vault_rpc_client, make_wallet, save_config,
+        wait_for_seqno_change, wallet_address, wallet_info, warn_missing_secret,
+        warn_ton_api_unavailable,
     },
 };
 use anyhow::Context;
@@ -40,9 +41,6 @@ const ELECTOR_STAKE_FEE: u64 = 1_000_000_000;
 const NPOOL_COMPUTE_FEE: u64 = 200_000_000;
 /// Gas fee consumed by wallet to send message to nominator pool.
 const WALLET_COMPUTE_FEE: u64 = 100_000_000;
-
-/// Name shown for `master_wallet` in `config wallet ls` and accepted by `get_wallet_config`.
-const MASTER_WALLET_RESERVED_NAME: &str = "master_wallet";
 
 #[derive(clap::Args, Clone)]
 #[command(about = "Manage wallets in the configuration")]

--- a/src/node-control/commands/src/commands/nodectl/utils.rs
+++ b/src/node-control/commands/src/commands/nodectl/utils.rs
@@ -29,6 +29,9 @@ const POLL_INTERVAL: tokio::time::Duration = tokio::time::Duration::from_secs(2)
 pub const SEND_TIMEOUT: tokio::time::Duration = tokio::time::Duration::from_secs(15);
 pub const DEPLOY_TIMEOUT: tokio::time::Duration = tokio::time::Duration::from_secs(60);
 
+/// Logical name for the master wallet in CLI, `get_wallet_config`, and `config wallet ls`.
+pub const MASTER_WALLET_RESERVED_NAME: &str = "master_wallet";
+
 pub fn warn_missing_secret(secret_name: &str) {
     println!("\n{} {}", "[WARNING]".yellow().bold(), "Vault secret is missing".yellow(),);
     println!(
@@ -136,7 +139,11 @@ pub fn get_wallet_config<'a>(
     wallets: &'a HashMap<String, WalletConfig>,
     master_wallet: Option<&'a WalletConfig>,
 ) -> anyhow::Result<&'a WalletConfig> {
-    let config = if name == "master_wallet" { master_wallet } else { wallets.get(name) };
+    let config = if name == MASTER_WALLET_RESERVED_NAME {
+        master_wallet
+    } else {
+        wallets.get(name)
+    };
     config.ok_or_else(|| anyhow::anyhow!("Wallet not found '{}'", name))
 }
 

--- a/src/node-control/commands/src/commands/nodectl/utils.rs
+++ b/src/node-control/commands/src/commands/nodectl/utils.rs
@@ -139,11 +139,8 @@ pub fn get_wallet_config<'a>(
     wallets: &'a HashMap<String, WalletConfig>,
     master_wallet: Option<&'a WalletConfig>,
 ) -> anyhow::Result<&'a WalletConfig> {
-    let config = if name == MASTER_WALLET_RESERVED_NAME {
-        master_wallet
-    } else {
-        wallets.get(name)
-    };
+    let config =
+        if name == MASTER_WALLET_RESERVED_NAME { master_wallet } else { wallets.get(name) };
     config.ok_or_else(|| anyhow::anyhow!("Wallet not found '{}'", name))
 }
 


### PR DESCRIPTION
## Summary
Reserve the logical wallet name master_wallet in nodectl: operators cannot config wallet add a regular wallet with that name (it remains the master’s slot in config wallet ls), and config wallet rm fails immediately with a clear error when that name is used—without loading the config or suggesting “not found”. The name is defined once as MASTER_WALLET_RESERVED_NAME in utils.rs and reused by get_wallet_config, WalletAddCmd, WalletLsCmd, and WalletRmCmd so resolution and CLI checks stay aligned.

## Changes
- `utils.rs`
Add public `MASTER_WALLET_RESERVED_NAME` ("master_wallet") with a short comment: CLI / get_wallet_config / config wallet ls.
get_wallet_config: resolve the master wallet when name == `MASTER_WALLET_RESERVED_NAME` instead of a hardcoded literal.
- `config_wallet_cmd.rs`
Import `MASTER_WALLET_RESERVED_NAME` from utils (no duplicate local constant).
WalletAddCmd: reject --name equal to `MASTER_WALLET_RESERVED_NAME`; error text uses the constant (e.g. '{}' is a reserved name).
WalletLsCmd: append the master row with `MASTER_WALLET_RESERVED_NAME`.
WalletRmCmd: before AppConfig::load, if the target equals `MASTER_WALLET_RESERVED_NAME`, bail with The master wallet cannot be removed (no config mutation).

Closes SMA-48