### PR TITLE
fix(elections): correct next_elections time range formula

### DIFF
--- a/src/node-control/elections/src/runner.rs
+++ b/src/node-control/elections/src/runner.rs
@@ -215,20 +215,27 @@ struct SnapshotCache {
 impl SnapshotCache {
     fn update_next_elections_range(&mut self, cfg15: &ConfigParam15) {
         if let Some(vset) = &self.last_validator_set {
-            let next_elections_start = if time_format::now()
-                > vset.utime_until().saturating_sub(cfg15.elections_start_before) as u64
-            {
-                vset.utime_until().saturating_add(cfg15.elections_start_before)
+            let now = time_format::now();
+            let elections_start_before = cfg15.elections_start_before as u64;
+            let elections_end_before = cfg15.elections_end_before as u64;
+            let validators_elected_for = cfg15.validators_elected_for as u64;
+            // utime_until of the current validator set == election_id of the next cycle.
+            let current_cycle_end = vset.utime_until() as u64;
+            let upcoming_elections_end = current_cycle_end.saturating_sub(elections_end_before);
+            // If the upcoming cycle's elections window has already closed, advance to the
+            // cycle after that.
+            let next_cycle_election_id = if now >= upcoming_elections_end {
+                current_cycle_end.saturating_add(validators_elected_for)
             } else {
-                vset.utime_since().saturating_add(cfg15.elections_start_before)
+                current_cycle_end
             };
-            let next_elections_end = next_elections_start
-                .saturating_add(cfg15.elections_start_before + cfg15.elections_end_before);
+            let start = next_cycle_election_id.saturating_sub(elections_start_before);
+            let end = next_cycle_election_id.saturating_sub(elections_end_before);
             self.next_elections_range = Some(TimeRange {
-                start: next_elections_start as u64,
-                start_utc: time_format::format_ts(next_elections_start as u64),
-                end: next_elections_end as u64,
-                end_utc: time_format::format_ts(next_elections_end as u64),
+                start,
+                start_utc: time_format::format_ts(start),
+                end,
+                end_utc: time_format::format_ts(end),
             });
         }
     }

--- a/src/node-control/elections/src/runner_tests.rs
+++ b/src/node-control/elections/src/runner_tests.rs
@@ -23,7 +23,7 @@ use mockall::mock;
 use std::{collections::HashMap, sync::Arc, time::Duration};
 use ton_block::{
     BuilderData, Cell, Coins, ConfigParam15, Deserializable, MsgAddressInt, Number16, SliceData,
-    ValidatorSet,
+    ValidatorDescr, ValidatorSet,
     config_params::{ConfigParam16, ConfigParam17},
     read_single_root_boc,
 };
@@ -2810,4 +2810,73 @@ async fn test_toncore_nominator_elections_finished_checks_active_pool_only() {
     // Router now resolves a single active pool address; participant from non-active slot is not matched.
     assert!(!node.stake_accepted);
     assert_eq!(node.accepted_stake_amount, None);
+}
+
+// =====================================================
+// TEST: SnapshotCache::update_next_elections_range
+// =====================================================
+
+fn make_vset(utime_since: u32, utime_until: u32) -> ValidatorSet {
+    ValidatorSet::new(utime_since, utime_until, 1, vec![ValidatorDescr::default()])
+        .expect("validator set")
+}
+
+#[test]
+fn next_elections_range_before_window_opens_points_at_upcoming_cycle() {
+    let cfg15 = default_cfg15();
+    let now = time_format::now() as u32;
+    // Place utime_until far enough in the future that the upcoming cycle's
+    // elections window has not opened yet (i.e. now < utime_until - elections_start_before).
+    let utime_until = now + cfg15.elections_start_before + 3600;
+    let vset = make_vset(utime_until - cfg15.validators_elected_for, utime_until);
+    let mut cache = SnapshotCache { last_validator_set: Some(vset), ..Default::default() };
+
+    cache.update_next_elections_range(&cfg15);
+
+    let range = cache.next_elections_range.expect("range set");
+    assert_eq!(range.start, (utime_until - cfg15.elections_start_before) as u64);
+    assert_eq!(range.end, (utime_until - cfg15.elections_end_before) as u64);
+    assert_eq!(
+        range.end - range.start,
+        (cfg15.elections_start_before - cfg15.elections_end_before) as u64,
+    );
+}
+
+#[test]
+fn next_elections_range_inside_window_still_points_at_upcoming_cycle() {
+    let cfg15 = default_cfg15();
+    let now = time_format::now() as u32;
+    // Window currently open: now > utime_until - elections_start_before AND
+    // now < utime_until - elections_end_before. Pick utime_until = now + (end_before + 600).
+    let utime_until = now + cfg15.elections_end_before + 600;
+    let vset = make_vset(utime_until - cfg15.validators_elected_for, utime_until);
+    let mut cache = SnapshotCache { last_validator_set: Some(vset), ..Default::default() };
+
+    cache.update_next_elections_range(&cfg15);
+
+    let range = cache.next_elections_range.expect("range set");
+    assert_eq!(range.start, (utime_until - cfg15.elections_start_before) as u64);
+    assert_eq!(range.end, (utime_until - cfg15.elections_end_before) as u64);
+}
+
+#[test]
+fn next_elections_range_after_window_closed_advances_to_next_next_cycle() {
+    let cfg15 = default_cfg15();
+    let now = time_format::now() as u32;
+    // Upcoming cycle's elections already closed: now >= utime_until - elections_end_before.
+    // Pick utime_until = now + 60 so upcoming_elections_end = now - 540.
+    let utime_until = now + 60;
+    let vset = make_vset(utime_until - cfg15.validators_elected_for, utime_until);
+    let mut cache = SnapshotCache { last_validator_set: Some(vset), ..Default::default() };
+
+    cache.update_next_elections_range(&cfg15);
+
+    let range = cache.next_elections_range.expect("range set");
+    let next_cycle_id = utime_until + cfg15.validators_elected_for;
+    assert_eq!(range.start, (next_cycle_id - cfg15.elections_start_before) as u64);
+    assert_eq!(range.end, (next_cycle_id - cfg15.elections_end_before) as u64);
+    assert_eq!(
+        range.end - range.start,
+        (cfg15.elections_start_before - cfg15.elections_end_before) as u64,
+    );
 }


### PR DESCRIPTION
# Summary

- Fixed calculation of the next elections range in `/v1/elections` response.

Fix `update_next_elections_range`: derive start/end from `vset.utime_until()` (next cycle's `election_id`); duration = `elections_start_before - elections_end_before`. Advance to cycle-after-next once the upcoming window has closed. Adds 3 unit tests.

Closes SMA-53