### PR TITLE
chore(nodectl): prep v0.4.0 release

### DIFF
--- a/helm/nodectl/CHANGELOG.md
+++ b/helm/nodectl/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the nodectl Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 Versions follow the Helm chart release tags (e.g. `helm/nodectl/v0.1.0`).
 
+## [0.2.1] - 2026-04-16
+
+appVersion: `v0.4.0`
+
+### Changed
+
+- Default image updated to nodectl `v0.4.0`
+
 ## [0.2.0] - 2026-03-24
 
 appVersion: `v0.3.0`

--- a/helm/nodectl/Chart.yaml
+++ b/helm/nodectl/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: nodectl
 description: TON Node Control Tool — validator elections, voting, and monitoring
 type: application
-version: 0.2.0
-appVersion: "v0.3.0"
+version: 0.2.1
+appVersion: "v0.4.0"
 
 sources:
   - https://github.com/rsquad/ton-rust-node

--- a/helm/nodectl/values.yaml
+++ b/helm/nodectl/values.yaml
@@ -12,7 +12,7 @@ replicas: 1
 ##
 image:
   repository: ghcr.io/rsquad/ton-rust-node/nodectl
-  tag: "v0.3.0"
+  tag: "v0.4.0"
   pullPolicy: IfNotPresent
 
 ## @param imagePullSecrets [array] Registry pull secrets for private container images

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "adnl",
  "anyhow",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "adnl",
  "anyhow",
@@ -970,7 +970,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "contracts"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "control-client"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "adnl",
  "anyhow",
@@ -1578,7 +1578,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elections"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "adnl",
  "anyhow",
@@ -3293,7 +3293,7 @@ dependencies = [
 
 [[package]]
 name = "nodectl"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap 4.6.0",
@@ -4899,7 +4899,7 @@ dependencies = [
 
 [[package]]
 name = "service"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "adnl",
  "anyhow",
@@ -5560,7 +5560,7 @@ dependencies = [
 
 [[package]]
 name = "ton-http-api-client"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src/node-control/CHANGELOG.md
+++ b/src/node-control/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **master_wallet duplication / deletion** — reserved the logical name `master_wallet` so it cannot collide with a regular wallet entry.
+- **next elections range in `/v1/elections` response** - fixed calculation of next elections range in `/v1/elections` response.
 
 ## [0.3.0] - 2026-03-24
 

--- a/src/node-control/CHANGELOG.md
+++ b/src/node-control/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-04-16
+
+### Added
+
+- **TONCore Nominator Pool support** — new pool kind `"core"` with two logical slots (`pools[0]`/`pools[1]`) for even/odd validation rounds. CLI: `config pool add core --even|--odd`, `config pool deposit-validator`, `config pool withdraw-validator`. Runtime routes stakes to the free pool via a dual-pool router and matches stake recovery across both inner pool addresses.
+- **Adaptive staking strategy (`adaptive_split50`)** — emulates the Elector's selection algorithm to estimate the minimum effective stake for the current round, then splits half when the remaining half is still competitive and stakes all otherwise. Adds `sleep_period_pct` / `waiting_period_pct` to the `elections` config. See `docs/staking-strategies.md`.
+- **Centralised config management through REST API** — all `config` mutations (entity CRUD, settings, logging, TON HTTP API) now flow through JWT-authenticated REST endpoints on the running service, with the CLI acting as a thin client. New endpoints:
+  - `POST|DELETE /v1/nodes`, `POST|DELETE /v1/wallets`, `POST|DELETE /v1/pools`, `POST|DELETE /v1/bindings`
+  - `POST /v1/elections/settings` (unified stake policy, per-node overrides, `tick_interval`, `max_factor`)
+  - `POST /v1/ton-http-api` (with `append` flag for failover endpoints)
+  - `POST /v1/log`
+  - `GET /v1/elections/settings`, `GET /v1/nodes`, `GET /v1/wallets`, `GET /v1/pools`, `GET /v1/bindings`, `GET /v1/log`, `GET /v1/master-wallet`
+- **Voting CLI (`nodectl vote`)** — `ls`, `inspect`, `add`, `rm` subcommands to view on-chain config proposals and manage the voting task's tracked-proposals list.
+- **Reserved `master_wallet` name** — `config wallet add` rejects the reserved name `master_wallet`, and `config wallet rm master_wallet` fails immediately with a clear error instead of attempting to mutate the master wallet slot.
+
+### Changed
+
+- **`max_factor` upper bound read from the network** — instead of the hardcoded `3.0`, nodectl now reads the limit from masterchain config param 17 (`max_stake_factor`).
+- **Unified elections settings endpoint** — `POST /v1/elections/settings` replaces the removed `/v1/stake_strategy`, `/v1/elections/tick-interval`, and `/v1/elections/max-factor`. Accepts any combination of `policy`, `node`, `reset`, `tick_interval`, `max_factor` in one request.
+- **Unified TON HTTP API endpoint** — `POST /v1/ton-http-api` replaces the separate `set`/`add` endpoints; pass `append: true` to keep existing URLs.
+
+### Breaking Changes
+
+- **Removed `POST /v1/stake_strategy`** — use `POST /v1/elections/settings` with `{"policy": ...}`.
+- **Removed `config stake-policy` top-level alias** — use `config elections stake-policy`.
+- **`config ton-http-api set --url` → `--endpoint`** — the flag was renamed (short form `-e`) to disambiguate from the root `--url` service-URL flag introduced for REST client commands. Update any scripts invoking `nodectl config ton-http-api --url ...`.
+- **Configuration mutations require a running service** — `config {node,wallet,pool,bind,elections,log,ton-http-api,master-wallet}` subcommands are now REST clients and need the service to be running with an operator user. Only `config generate` still writes to disk directly.
+
+### Fixed
+
+- **master_wallet duplication / deletion** — reserved the logical name `master_wallet` so it cannot collide with a regular wallet entry.
+
 ## [0.3.0] - 2026-03-24
 
 ### Added

--- a/src/node-control/README.md
+++ b/src/node-control/README.md
@@ -1934,6 +1934,8 @@ When a pool is present in the binding configuration:
 
 Each binding resolves its effective stake policy by checking for a per-node override first (`policy_overrides`); if none is set, the default `policy` is used. This allows running nodes with different stake strategies under a single configuration.
 
+> **TONCore nominator caveat.** `Split50` and `AdaptiveSplit50` are ignored on bindings backed by a TONCore nominator — the two pools stake in different rounds, so there is nothing to split. The runner stakes the full liquid balance of the selected pool instead (still floored at `min_stake`). Use `Fixed` or `Minimum` if you need to cap per-round exposure on TONCore.
+
 ### Logging
 
 Configure logging output and level in the config file (`log` section). Override the log level temporarily via environment variable:

--- a/src/node-control/README.md
+++ b/src/node-control/README.md
@@ -20,6 +20,7 @@
   - [Service Command](#service-command)
   - [Service API Commands](#service-api-commands)
   - [TON HTTP API](#ton-http-api)
+  - [Voting Commands](#voting-commands)
 - [REST API Endpoints](#rest-api-endpoints)
 - [Configuration](#configuration)
   - [Config Structure](#config-structure)
@@ -127,7 +128,7 @@ RUST_LOG=debug nodectl ...
 
 ### Configuration Commands
 
-Commands for managing nodectl configuration files. All `config` subcommands accept a global `--config` (`-c`) flag to specify the configuration file path (default: `nodectl-config.json`). This can also be set via the `CONFIG_PATH` environment variable.
+Commands for managing nodectl configuration. **All `config` subcommands except `config generate` are REST clients that require a running nodectl service** — they talk to the daemon over the HTTP API. The service URL is resolved (in order) from `--url` / `-u` (or the `NODECTL_URL` env var), or from `http.bind` inside `--config` (default `nodectl-config.json`, env `CONFIG_PATH`). Protected endpoints require an `operator` JWT token passed via `--token` (or the `NODECTL_API_TOKEN` env var) — see the [Authentication Commands](#authentication-commands) section for how to obtain one.
 
 #### `config generate`
 
@@ -278,10 +279,11 @@ nodectl config wallet send \
 
 #### `config pool`
 
-Manage nominator pools in the configuration file. Pools are stored as tagged JSON: **`kind: "snp"`** or **`kind: "core"`**.
+Manage nominator pools in the configuration. Pools are stored as tagged JSON: **`kind: "snp"`** or **`kind: "core"`**. Both add variants, `ls`, and `rm` flow through the REST API on the running service.
 
 - **`config pool add`** — **Single Nominator Pool (SNP)** only (`PoolConfig::SNP`: optional `address`, `owner`).
 - **`config pool add core`** — **TONCore nominator** (`PoolConfig::TONCore`): up to **two** logical slots (`pools[0]`, `pools[1]`) for even/odd validation rounds. Each slot is configured by a separate command call with explicit **`--even`** or **`--odd`**, and optional `address` and/or deploy `params` (`TonCoreInitParams`) for that slot.
+- **`config pool deposit-validator` / `withdraw-validator`** — TONCore-only validator deposit/withdrawal flows that build and send the on-chain message through a configured wallet (require vault access; not a REST client).
 
 ##### `config pool add` (SNP)
 
@@ -362,6 +364,30 @@ Remove a pool from the configuration.
 nodectl config pool rm --name pool0
 ```
 
+##### `config pool deposit-validator` (TONCore only)
+
+Deposit validator funds into a TONCore nominator pool. Builds and sends the on-chain deposit message through the binding's configured wallet.
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--binding <NAME>` | `-b` | Binding name (resolves wallet and pool) |
+| `--amount <TON>` | `-a` | Amount in TON to deposit |
+| `--pool-even` | | Use the pool for even validation rounds (default if neither flag is set) |
+| `--pool-odd` | | Use the pool for odd validation rounds |
+| `--yes` | | Skip the interactive confirmation prompt |
+
+```bash
+nodectl config pool deposit-validator --binding node0 --amount 10000 --pool-even
+```
+
+##### `config pool withdraw-validator` (TONCore only)
+
+Withdraw validator funds from a TONCore nominator pool. Same flags as `deposit-validator`.
+
+```bash
+nodectl config pool withdraw-validator --binding node0 --amount 5000 --pool-odd
+```
+
 ---
 
 #### `config bind`
@@ -421,21 +447,40 @@ Configure the TON HTTP API connection settings.
 
 ##### `config ton-http-api set`
 
-Set the TON HTTP API URL and optional API key.
+Replace the TON HTTP API endpoint list with a single URL and optional API key.
 
 | Flag | Short form | Description |
 |------|------------|-------------|
-| `--url <URL>` | `-u` | TON HTTP API URL |
+| `--endpoint <URL>` | `-e` | TON HTTP API endpoint URL |
 | `--api-key <KEY>` | `-k` | API key (optional) |
 
 ```bash
-# Set TON HTTP API URL
-nodectl config ton-http-api set --url "https://toncenter.com/api/v2/jsonRpc"
+# Set a single TON HTTP API endpoint
+nodectl config ton-http-api set --endpoint "https://toncenter.com/api/v2/jsonRpc"
 
-# Set with API key
+# Set endpoint with API key
 nodectl config ton-http-api set \
-  --url "https://toncenter.com/api/v2/jsonRpc" \
+  --endpoint "https://toncenter.com/api/v2/jsonRpc" \
   --api-key "your-api-key"
+```
+
+##### `config ton-http-api add`
+
+Append one or more failover endpoints (existing endpoints are preserved; duplicates are skipped).
+
+| Flag | Short form | Description |
+|------|------------|-------------|
+| `--endpoint <URL>` | `-e` | TON HTTP API endpoint URL (repeat to add more than one) |
+| `--api-key <KEY>` | `-k` | Per-endpoint API key applied to every URL in this invocation (optional; falls back to the global key) |
+
+```bash
+# Add a single failover endpoint
+nodectl config ton-http-api add --endpoint "https://backup.example/api/v2/jsonRpc"
+
+# Add multiple failover endpoints in one invocation
+nodectl config ton-http-api add \
+  --endpoint "https://backup1.example/api/v2/jsonRpc" \
+  --endpoint "https://backup2.example/api/v2/jsonRpc"
 ```
 
 ---
@@ -525,6 +570,7 @@ Set the default or per-node stake policy in the elections configuration.
 | `--fixed <AMOUNT>` | | Fixed stake amount in TON |
 | `--split50` | | Use 50% of available balance |
 | `--minimum` | | Use minimum required stake |
+| `--adaptive-split50` | | Adaptive: split half when above Elector's minimum effective stake, otherwise stake all (see [Staking Strategies](./docs/staking-strategies.md)) |
 | `--node <NAME>` | `-n` | Apply policy only to this node (override). Omit to set the default policy. |
 | `--reset` | | Remove a per-node policy override (requires `--node`) |
 
@@ -534,6 +580,9 @@ nodectl config elections stake-policy --minimum
 
 # Set fixed stake (1000 TON)
 nodectl config elections stake-policy --fixed 1000
+
+# Set adaptive split50
+nodectl config elections stake-policy --adaptive-split50
 
 # Override policy for a specific node
 nodectl config elections stake-policy --node node0 --fixed 500
@@ -588,37 +637,6 @@ Disable elections participation for one or more bindings.
 
 ```bash
 nodectl config elections disable node0
-```
-
----
-
-#### `config stake-policy`
-
-Shortcut for `config elections stake-policy`. Set the stake policy in the configuration file. By default the policy applies to **all nodes**. Use `--node` to set a per-node override that takes precedence over the default.
-
-| Flag | Short form | Description |
-|------|------------|-------------|
-| `--fixed <AMOUNT>` | | Fixed stake amount in TON |
-| `--split50` | | Use 50% of available balance |
-| `--minimum` | | Use minimum required stake |
-| `--node <NAME>` | `-n` | Apply policy only to this node (per-node override). Omit to set the default policy for all nodes. |
-| `--reset` | | Remove a per-node policy override (requires `--node`) |
-
-```bash
-# Set minimum stake policy (default for all nodes)
-nodectl config stake-policy --minimum
-
-# Set fixed stake (1000 TON)
-nodectl config stake-policy --fixed 1000
-
-# Set split50 policy
-nodectl config stake-policy --split50
-
-# Override policy for a specific node
-nodectl config stake-policy --node node0 --fixed 500
-
-# Remove a per-node override (node falls back to default policy)
-nodectl config stake-policy --node node0 --reset
 ```
 
 ---
@@ -955,13 +973,14 @@ nodectl api task elections restart
 
 ##### `api stake-policy`
 
-Set the stake policy for elections on a running service. Use `--node` to set a per-node override instead of changing the default policy.
+Set the stake policy for elections on a running service. Use `--node` to set a per-node override instead of changing the default policy. This command is a shortcut for `POST /v1/elections/settings`.
 
 | Flag | Short form | Description |
 |------|------------|-------------|
 | `--fixed <AMOUNT>` | | Fixed stake amount (in nanoTON) |
 | `--split50` | | Use 50% of available balance |
 | `--minimum` | | Use minimum required stake |
+| `--adaptive-split50` | | Adaptive: split half when above Elector's minimum effective stake, otherwise stake all |
 | `--node <NAME>` | `-n` | Apply policy only to this node (per-node override). Omit to set the default policy. |
 
 ```bash
@@ -973,6 +992,9 @@ nodectl api stake-policy --fixed 1000000000000
 
 # Set split50 policy
 nodectl api stake-policy --split50
+
+# Set adaptive split50
+nodectl api stake-policy --adaptive-split50
 
 # Override policy for a specific node
 nodectl api stake-policy --node node0 --fixed 500000000000
@@ -995,6 +1017,51 @@ Get a configuration parameter from the blockchain (via TON HTTP API).
 
 ```bash
 nodectl config-param -c config.json 34
+```
+
+---
+
+### Voting Commands
+
+On-chain config proposal voting. `nodectl vote ls` / `inspect` hit the Config contract via TON HTTP API. `nodectl vote add` / `rm` manage the local `voting.proposals` list used by the voting task — they write directly to the config file and do **not** require a running service.
+
+#### `vote ls`
+
+List active config proposals on-chain. Proposals already tracked by the voting task are marked with `*`.
+
+| Flag | Description |
+|------|-------------|
+| `--format <FORMAT>` | `table` (default) or `json` |
+
+```bash
+nodectl vote ls
+```
+
+#### `vote inspect`
+
+Show full details (expires-in, voters, weight remaining, param cell BOC, param hash) for a proposal by hex hash.
+
+```bash
+nodectl vote inspect <HEX_HASH>
+nodectl vote inspect <HEX_HASH> --format json
+```
+
+#### `vote add`
+
+Add a proposal to the voting task's tracked list. Pass `--hash <HEX_HASH>` or invoke interactively to pick one from the list of active proposals.
+
+```bash
+nodectl vote add --hash <HEX_HASH>
+nodectl vote add   # interactive
+```
+
+#### `vote rm`
+
+Remove a proposal from the voting task's tracked list.
+
+```bash
+nodectl vote rm --hash <HEX_HASH>
+nodectl vote rm    # interactive
 ```
 
 ---
@@ -1025,17 +1092,46 @@ The HTTP server is configured in the `http` section of the config:
 
 ### Endpoints
 
+All endpoints return `{ "ok": true, ... }` on success and `{ "ok": false, "error": { "code": <http>, "message": "..." } }` on failure. `200` indicates success; `400`, `401`, `403`, `404`, `429`, `500` are used as documented.
+
+Role columns use the following shorthand: **P** = public (no token), **N** = `nominator` or `operator`, **O** = `operator` only.
+
+| Method | Path | Role | Summary |
+|--------|------|------|---------|
+| GET | `/health` | P | Health check |
+| GET | `/openapi.json` | P | OpenAPI spec |
+| GET | `/swagger`, `/swagger-ui` | P | Swagger UI (when `enable_swagger` is `true`) |
+| POST | `/auth/login` | P | Exchange username/password for a JWT |
+| GET | `/auth/me` | N | Identity of the authenticated user |
+| GET | `/auth/users` | O | List users |
+| GET | `/v1/elections` | N | Current elections snapshot |
+| POST | `/v1/elections/exclude` | O | Disable elections for given bindings |
+| POST | `/v1/elections/include` | O | Enable elections for given bindings |
+| GET | `/v1/elections/settings` | N | Elections configuration (policy, overrides, tick, max-factor, per-binding status) |
+| POST | `/v1/elections/settings` | O | Update elections settings (policy, per-node override, tick, max-factor) |
+| GET | `/v1/validators` | N | Validators snapshot for controlled nodes |
+| POST | `/v1/task/elections` | O | Enable / disable / restart the elections background task |
+| GET | `/v1/nodes` | N | List configured nodes with control-server status |
+| POST | `/v1/nodes` | O | Add a node |
+| DELETE | `/v1/nodes/{name}` | O | Remove a node |
+| GET | `/v1/wallets` | N | List configured wallets with on-chain state |
+| POST | `/v1/wallets` | O | Add a wallet |
+| DELETE | `/v1/wallets/{name}` | O | Remove a wallet |
+| GET | `/v1/pools` | N | List configured pools with live balances |
+| POST | `/v1/pools` | O | Add a pool (SNP or TONCore) |
+| DELETE | `/v1/pools/{name}` | O | Remove a pool |
+| GET | `/v1/bindings` | N | List node bindings |
+| POST | `/v1/bindings` | O | Add a binding |
+| DELETE | `/v1/bindings/{node}` | O | Remove a binding (requires `idle` status) |
+| GET | `/v1/log` | N | Current log configuration |
+| POST | `/v1/log` | O | Update log settings |
+| POST | `/v1/ton-http-api` | O | Replace or append TON HTTP API endpoints |
+| GET | `/v1/master-wallet` | N | Master wallet address, balance, version |
+
 #### `GET /health`
 
-Health check endpoint.
-
-**Response:**
-
 ```json
-{
-  "ok": true,
-  "result": "OK"
-}
+{ "ok": true, "result": "OK" }
 ```
 
 ---
@@ -1047,10 +1143,7 @@ Authenticate and obtain a JWT token. Rate-limited: 5 failed attempts per 60s win
 **Request:**
 
 ```json
-{
-  "username": "admin",
-  "password": "secret"
-}
+{ "username": "admin", "password": "secret" }
 ```
 
 **Response:**
@@ -1068,25 +1161,17 @@ Authenticate and obtain a JWT token. Rate-limited: 5 failed attempts per 60s win
 
 #### `GET /auth/me`
 
-Return the identity of the authenticated user. Requires: `nominator` or `operator` role.
-
-**Response:**
+Return the identity of the authenticated user.
 
 ```json
-{
-  "ok": true,
-  "username": "admin",
-  "role": "operator"
-}
+{ "ok": true, "username": "admin", "role": "operator" }
 ```
 
 ---
 
 #### `GET /auth/users`
 
-List all users. Requires: `operator` role.
-
-**Response:**
+List all users.
 
 ```json
 {
@@ -1102,37 +1187,51 @@ List all users. Requires: `operator` role.
 
 #### `GET /v1/elections`
 
-Get current elections snapshot. Requires: `nominator` or `operator` role.
+Current elections snapshot. Pass `?include_participants=true` to include the full participants list (omitted by default to keep the response small).
 
 **Response:**
 
 ```json
 {
   "ok": true,
+  "status": "active",
   "result": {
     "election_id": 1734523200,
     "elect_close": 1734522300,
-    "min_stake": 300000000000000,
-    "total_stake": 15000000000000000,
-    "participants": [...],
+    "elect_close_utc": "2024-12-18 10:45:00",
+    "finished": false,
     "failed": false,
-    "finished": false
-  }
+    "participants_count": 42,
+    "min_stake": "300000000000000",
+    "participant_min_stake": "400000000000000",
+    "participant_max_stake": "1200000000000000",
+    "participants": []
+  },
+  "next_elections": {
+    "start": 1734530000,
+    "start_utc": "2024-12-18 12:00:00",
+    "end": 1734616400,
+    "end_utc": "2024-12-19 12:00:00"
+  },
+  "our_participants": []
 }
 ```
+
+- `status` is one of `closed`, `active`, `finished`, `failed`, `postponed`.
+- `result` is `null` when no snapshot has been collected yet.
+- Stake fields (`min_stake`, `participant_*`, per-participant `stake`) are **strings** of nanotons (decimal).
+- `our_participants[]` lists each controlled node's participation lifecycle (`status`: `idle → participating → submitted → accepted → elected → validating`) and stake submission history.
 
 ---
 
 #### `POST /v1/elections/exclude`
 
-Exclude nodes from elections participation.
+Disable elections for the given bindings (sets `enable: false`). Triggers an elections task restart.
 
 **Request:**
 
 ```json
-{
-  "nodes": ["node0", "node1"]
-}
+{ "nodes": ["node0", "node1"] }
 ```
 
 **Response:**
@@ -1151,15 +1250,17 @@ Exclude nodes from elections participation.
 
 #### `POST /v1/elections/include`
 
-Include nodes back into elections participation.
-
-**Request:**
+Enable elections for the given bindings (sets `enable: true`). Same response shape as `/exclude` — `excluded` lists bindings that remain disabled.
 
 ```json
-{
-  "nodes": ["node0"]
-}
+{ "nodes": ["node0"] }
 ```
+
+---
+
+#### `GET /v1/elections/settings`
+
+Return the effective elections configuration plus per-binding status.
 
 **Response:**
 
@@ -1167,8 +1268,71 @@ Include nodes back into elections participation.
 {
   "ok": true,
   "result": {
-    "excluded": ["node1"],
-    "updated_at": 1734523200
+    "stake_policy": "split50",
+    "policy_overrides": { "node0": { "fixed": 500000000000 } },
+    "max_factor": 3.0,
+    "tick_interval": 40,
+    "bindings": [
+      {
+        "name": "node0",
+        "enable": true,
+        "status": "validating",
+        "stake_policy": { "fixed": 500000000000 }
+      }
+    ]
+  }
+}
+```
+
+---
+
+#### `POST /v1/elections/settings`
+
+Unified endpoint for updating elections settings. Replaces the pre-0.4 `POST /v1/stake_strategy`, `POST /v1/elections/tick-interval`, and `POST /v1/elections/max-factor`. At least one field must be set.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `policy` | `StakePolicy` | Stake policy to set; ignored when `reset` is `true` |
+| `node` | `string` | Target node for a per-node override (omit for the default policy) |
+| `reset` | `bool` | Remove a per-node override (requires `node`) |
+| `tick_interval` | `u64` | Elections tick interval in seconds |
+| `max_factor` | `f32` | Validated against masterchain config param 17 |
+
+`StakePolicy` is `"minimum"`, `"split50"`, `"adaptive_split50"`, or `{ "fixed": <nanotons> }`.
+
+**Example — update policy + tick interval + max factor in one call:**
+
+```json
+{
+  "policy": "adaptive_split50",
+  "tick_interval": 60,
+  "max_factor": 2.5
+}
+```
+
+**Per-node override:**
+
+```json
+{ "policy": { "fixed": 500000000000 }, "node": "node0" }
+```
+
+**Reset a per-node override:**
+
+```json
+{ "reset": true, "node": "node0" }
+```
+
+**Response** — returns the new settings (same shape as `GET` but without `bindings`):
+
+```json
+{
+  "ok": true,
+  "result": {
+    "stake_policy": "adaptive_split50",
+    "policy_overrides": {},
+    "max_factor": 2.5,
+    "tick_interval": 60,
+    "bindings": []
   }
 }
 ```
@@ -1177,7 +1341,7 @@ Include nodes back into elections participation.
 
 #### `GET /v1/validators`
 
-Get current validators snapshot.
+Validators snapshot for controlled nodes only.
 
 **Response:**
 
@@ -1185,73 +1349,31 @@ Get current validators snapshot.
 {
   "ok": true,
   "result": {
-    "validators": [...],
-    "utime_since": 1734400000,
-    "utime_until": 1734486400
-  }
-}
-```
-
----
-
-#### `POST /v1/stake_strategy`
-
-Set the stake policy for elections. Optionally include a `node` field to apply the policy as a per-node override instead of changing the default.
-
-**Request (default policy — minimum stake):**
-
-```json
-{
-  "policy": "minimum"
-}
-```
-
-**Request (default policy — fixed stake):**
-
-```json
-{
-  "policy": { "fixed": 1000000000000 }
-}
-```
-
-**Request (default policy — split50):**
-
-```json
-{
-  "policy": "split50"
-}
-```
-
-**Request (per-node override):**
-
-```json
-{
-  "policy": { "fixed": 500000000000 },
-  "node": "node0"
-}
-```
-
-**Response:**
-
-```json
-{
-  "ok": true,
-  "result": {
-    "policy": "minimum",
-    "applied_at": 1734523200
-  }
-}
-```
-
-**Response (per-node override):**
-
-```json
-{
-  "ok": true,
-  "result": {
-    "policy": { "fixed": 500000000000 },
-    "node": "node0",
-    "applied_at": 1734523200
+    "controlled_nodes": [
+      {
+        "node_id": "node0",
+        "is_validator": true,
+        "validator_index": 42,
+        "weight": 1000,
+        "wallet_addr": "-1:...",
+        "stake": "25000000000000",
+        "stake_accepted": true,
+        "key_election_id": 1734400000,
+        "key_expires_at_utc": "2024-12-19 08:00:00",
+        "is_key_active": true,
+        "key_id": "<base64>",
+        "pubkey": "<base64>",
+        "adnl": "<base64>",
+        "binding_status": "validating"
+      }
+    ],
+    "default_stake_policy": "split50",
+    "validation_range": {
+      "start": 1734400000,
+      "start_utc": "2024-12-17 08:00:00",
+      "end": 1734486400,
+      "end_utc": "2024-12-18 08:00:00"
+    }
   }
 }
 ```
@@ -1265,10 +1387,10 @@ Control the elections background task.
 **Request:**
 
 ```json
-{
-  "action": "enable" | "disable" | "restart"
-}
+{ "action": "enable" }
 ```
+
+`action` is `enable`, `disable`, or `restart`.
 
 **Response:**
 
@@ -1279,6 +1401,240 @@ Control the elections background task.
     "enabled": true,
     "status": "running",
     "updated_at": 1734523200
+  }
+}
+```
+
+`status` is `running` or `stopped`.
+
+---
+
+#### `GET /v1/nodes`
+
+List configured nodes with a concurrent ADNL connectivity probe (5s timeout).
+
+```json
+{
+  "ok": true,
+  "result": [
+    {
+      "name": "node0",
+      "control_server_endpoint": "192.168.1.100:50000",
+      "control_server_pubkey": "<base64>",
+      "control_client_secret": "node0-adnl-key",
+      "status": "ok"
+    }
+  ]
+}
+```
+
+`status` is `ok`, `unknown`, or an error message (e.g. `timeout`, connection failure).
+
+#### `POST /v1/nodes`
+
+Add a node.
+
+**Request:**
+
+```json
+{
+  "name": "node0",
+  "control_server_endpoint": "192.168.1.100:50000",
+  "control_server_pubkey": "<base64>",
+  "control_client_secret": "node0-adnl-key"
+}
+```
+
+**Response:**
+
+```json
+{ "ok": true, "result": { "name": "node0" } }
+```
+
+#### `DELETE /v1/nodes/{name}`
+
+Remove a node. `400` if a binding still references it.
+
+```json
+{ "ok": true, "result": { "name": "node0" } }
+```
+
+---
+
+#### `GET /v1/wallets`
+
+List configured wallets (including the `master_wallet` slot when present) with live on-chain state. Addresses are bounceable URL-safe base64.
+
+```json
+{
+  "ok": true,
+  "result": [
+    {
+      "name": "wallet0",
+      "secret": "wallet0-key",
+      "version": "V3R2",
+      "state": "active",
+      "balance": 1200000000000,
+      "address": "EQ..."
+    }
+  ]
+}
+```
+
+`state` / `balance` are `null` when the TON HTTP API is unreachable.
+
+#### `POST /v1/wallets`
+
+```json
+{
+  "name": "wallet0",
+  "secret": "wallet0-key",
+  "version": "V3R2",
+  "subwallet_id": 42,
+  "workchain": -1
+}
+```
+
+`400` if the name is `master_wallet` (reserved) or already exists.
+
+#### `DELETE /v1/wallets/{name}`
+
+Remove a wallet. Refuses to delete `master_wallet`; `400` if referenced by a binding.
+
+---
+
+#### `GET /v1/pools`
+
+List configured pools with live balances and, for TONCore, per-slot addresses and validator share.
+
+```json
+{
+  "ok": true,
+  "result": [
+    {
+      "name": "pool0",
+      "kind": "SNP",
+      "balance": 900000000000,
+      "address": "EQ...",
+      "owner": "EQ..."
+    },
+    {
+      "name": "pool1",
+      "kind": "Core",
+      "balance": null,
+      "address": null,
+      "owner": null,
+      "addresses": ["EQ...", "<not deployed>"],
+      "validator_share": 5000
+    }
+  ]
+}
+```
+
+#### `POST /v1/pools`
+
+Add a pool (SNP or TONCore). At least one of `address` / `owner` is required for SNP; TONCore requires `kind: "core"` plus a `slot` (`even` / `odd`) and either `address` or `params` (`validator_share`, `max_nominators`, `min_validator_stake`, `min_nominator_stake`).
+
+**SNP example:**
+
+```json
+{ "name": "pool0", "owner": "EQ..." }
+```
+
+#### `DELETE /v1/pools/{name}`
+
+`400` if a binding still references the pool.
+
+---
+
+#### `GET /v1/bindings`
+
+```json
+{
+  "ok": true,
+  "result": [
+    { "node": "node0", "wallet": "wallet0", "pool": "pool0", "enable": true, "status": "validating" }
+  ]
+}
+```
+
+#### `POST /v1/bindings`
+
+```json
+{ "node": "node0", "wallet": "wallet0", "pool": "pool0" }
+```
+
+The node and wallet must already exist. A pool may be bound to at most one node.
+
+#### `DELETE /v1/bindings/{node}`
+
+Requires the binding to be in `idle` status. If it is `participating`, `draining`, or `validating`, disable elections first and wait for stake recovery.
+
+---
+
+#### `GET /v1/log`
+
+```json
+{
+  "ok": true,
+  "result": {
+    "level": "INFO",
+    "path": "./logs/nodectl.log",
+    "rotation": "daily",
+    "output": "all",
+    "max_size_mb": 50,
+    "max_files": 10
+  }
+}
+```
+
+#### `POST /v1/log`
+
+At least one field must be set. Setting `output` to `file` / `all` requires an existing `path` (either previously configured or provided in the same request).
+
+```json
+{ "level": "debug", "output": "all", "path": "/var/log/nodectl/service.log" }
+```
+
+---
+
+#### `POST /v1/ton-http-api`
+
+Replace or append TON HTTP API endpoints.
+
+**Request:**
+
+```json
+{
+  "urls": ["https://toncenter.com/api/v2/jsonRpc"],
+  "api_key": "your-api-key",
+  "append": false
+}
+```
+
+When `append` is `true`, the URLs are added after existing ones (duplicates skipped) and `api_key` applies to the newly added entries; when `false` (default), the list is fully replaced.
+
+**Response:**
+
+```json
+{ "ok": true, "result": { "endpoints": ["https://toncenter.com/api/v2/jsonRpc"] } }
+```
+
+---
+
+#### `GET /v1/master-wallet`
+
+```json
+{
+  "ok": true,
+  "result": {
+    "address": "EQ...",
+    "balance": 25000000000,
+    "state": "active",
+    "version": "V3R2",
+    "subwallet_id": 42,
+    "secret": "master-wallet-secret",
+    "public_key": "<base64>"
   }
 }
 ```
@@ -1324,13 +1680,16 @@ Configuration is specified in JSON format.
     }
   },
   "ton_http_api": {
-    "url": "http://127.0.0.1:3301/",
-    "api_key": "<OPTIONAL_API_KEY>" | null
+    "urls": [
+      "http://127.0.0.1:3301/",
+      { "url": "https://backup.example/api/v2/jsonRpc", "api_key": "<PER_ENDPOINT_KEY>" }
+    ],
+    "api_key": "<OPTIONAL_GLOBAL_KEY>" | null
   },
   "http": {
     "bind": "0.0.0.0:8080",
     "enable_swagger": true,
-    "api_key": null
+    "auth": { /* see http.auth below; omit or set to null to disable auth */ }
   },
   // optional
   "master_wallet": {
@@ -1341,10 +1700,12 @@ Configuration is specified in JSON format.
   },
   // optional
   "elections": {
-    "policy": "split50" | "minimum" | { "fixed": 1000000000000 },
-    "policy_overrides": { "<node_name>": "minimum" | { "fixed": <amount> } | "split50" },
+    "policy": "split50" | "minimum" | "adaptive_split50" | { "fixed": 1000000000000 },
+    "policy_overrides": { "<node_name>": "minimum" | { "fixed": <amount> } | "split50" | "adaptive_split50" },
     "max_factor": 3.0,
-    "tick_interval": 40
+    "tick_interval": 40,
+    "sleep_period_pct": 0.2,
+    "waiting_period_pct": 0.4
   },
   // optional
   "voting": {
@@ -1415,8 +1776,10 @@ Bindings link nodes to wallets and pools for elections participation:
 
 TON HTTP API configuration:
 
-- `url` — JSON-RPC endpoint URL (default: `http://127.0.0.1:3301/`)
-- `api_key` — API key (optional)
+- `urls` — ordered list of JSON-RPC endpoints. Each entry is either a plain URL string (uses the global `api_key`) or an object `{ "url": "...", "api_key": "..." }` with its own key. The first entry is the primary endpoint; the rest are used for failover. Default: `["http://127.0.0.1:3301/"]`.
+- `api_key` — global API key used for entries that don't specify their own (optional)
+
+> **Backward compatibility:** the legacy single-URL field `url` is still accepted on load and transparently migrated into the head of `urls` on the next save.
 
 #### `http`
 
@@ -1424,7 +1787,7 @@ HTTP REST API server configuration:
 
 - `bind` — address and port to bind (default: `0.0.0.0:8080`)
 - `enable_swagger` — enable Swagger UI at `/swagger` (default: `true`)
-- `auth` — JWT authentication configuration (see below)
+- `auth` — JWT authentication configuration (see below). Omit or set to `null` to disable authentication.
 
 #### `http.auth`
 
@@ -1451,10 +1814,13 @@ Automatic elections task configuration:
 - `policy` — default stake policy (applies to all nodes unless overridden):
   - `"split50"` — splits all available funds into two equal stakes (default)
   - `"minimum"` — use minimum required stake
+  - `"adaptive_split50"` — adaptive: splits half when above the Elector's estimated minimum effective stake for the current round, otherwise stakes all. See [Staking Strategies](./docs/staking-strategies.md).
   - `{ "fixed": <amount> }` — fixed stake amount in nanoTON
 - `policy_overrides` — per-node stake policy overrides (node name -> policy). When a node has an entry here, it takes precedence over the default `policy`. Example: `{ "node0": { "fixed": 500000000000 } }`
 - `max_factor` — maximum stake factor (default `3.0` in generated configs). Valid values lie in `[1.0, network_max_factor]`, where **`network_max_factor` comes from masterchain config param 17** (`max_stake_factor`); the CLI and stake command validate against the live network when TON HTTP API is available
 - `tick_interval` — interval between election checks in seconds (default: `40`)
+- `sleep_period_pct` — AdaptiveSplit50 minimum wait as a fraction of election duration. Default `0.2`. Must be in `[0.0, 1.0]` and ≤ `waiting_period_pct`.
+- `waiting_period_pct` — AdaptiveSplit50 maximum wait for enough participants as a fraction of election duration. Default `0.4`. Must be in `[0.0, 1.0]` and ≥ `sleep_period_pct`.
 
 #### `voting` (optional)
 
@@ -1563,6 +1929,7 @@ When a pool is present in the binding configuration:
 
 - `Split50` — split total available funds into two equal parts (default)
 - `Minimum` — minimum stake for election participation
+- `AdaptiveSplit50` — split half when above the Elector's estimated minimum effective stake, otherwise stake all (see [Staking Strategies](./docs/staking-strategies.md))
 - `Fixed(amount)` — fixed amount in nanoTON
 
 Each binding resolves its effective stake policy by checking for a per-node override first (`policy_overrides`); if none is set, the default `policy` is used. This allows running nodes with different stake strategies under a single configuration.
@@ -1612,7 +1979,7 @@ nodectl config bind add \
 
 # Set TON HTTP API
 nodectl config ton-http-api set \
-  --url "https://toncenter.com/api/v2/jsonRpc"
+  --endpoint "https://toncenter.com/api/v2/jsonRpc"
 
 # Enable elections for the binding
 nodectl config elections enable node0
@@ -1658,14 +2025,17 @@ nodectl config log set --level debug --output file --path /var/log/nodectl/node.
 # View elections configuration
 nodectl config elections show
 
-# Set default stake policy in config
-nodectl config stake-policy --minimum
+# Set default stake policy
+nodectl config elections stake-policy --minimum
+
+# Set adaptive split50
+nodectl config elections stake-policy --adaptive-split50
 
 # Override policy for a specific node
-nodectl config stake-policy --node node0 --fixed 500
+nodectl config elections stake-policy --node node0 --fixed 500
 
 # Remove a per-node override
-nodectl config stake-policy --node node0 --reset
+nodectl config elections stake-policy --node node0 --reset
 
 # Set elections tick interval
 nodectl config elections tick-interval 60
@@ -1763,7 +2133,7 @@ nodectl config wallet send \
 `nodectl config wallet stake` sends an election stake through a nominator pool. Use it to participate in elections manually.
 
 ```bash
-nodectl config wallet stake -b <BINDING> -a <AMOUNT> [-m <MAX_FACTOR>]
+nodectl config wallet stake -b <BINDING> -a <AMOUNT> [-m <MAX_FACTOR>] [--pool-even | --pool-odd]
 ```
 
 | Flag | Long | Required | Default | Description |
@@ -1771,6 +2141,8 @@ nodectl config wallet stake -b <BINDING> -a <AMOUNT> [-m <MAX_FACTOR>]
 | `-b` | `--binding` | Yes | — | Binding name (node-wallet-pool triple) |
 | `-a` | `--amount` | Yes | — | Stake amount in TON |
 | `-m` | `--max-factor` | No | `3.0` | Max factor: from `1.0` up to the network limit (**config param 17**), validated against the chain |
+|      | `--pool-even` | No | (default if neither flag is set) | TONCore only: use the pool for even validation rounds |
+|      | `--pool-odd` | No | — | TONCore only: use the pool for odd validation rounds |
 
 Example:
 
@@ -1836,6 +2208,9 @@ nodectl api stake-policy --fixed 1000000000000
 # Use 50% of available balance
 nodectl api stake-policy --split50
 
+# Use adaptive split50
+nodectl api stake-policy --adaptive-split50
+
 # Override policy for a specific node
 nodectl api stake-policy --node node0 --fixed 500000000000
 ```
@@ -1866,16 +2241,34 @@ curl -X POST http://127.0.0.1:8080/v1/elections/exclude \
   -d '{"nodes": ["node0"]}'
 
 # Set default stake policy
-curl -X POST http://127.0.0.1:8080/v1/stake_strategy \
+curl -X POST http://127.0.0.1:8080/v1/elections/settings \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $TOKEN" \
   -d '{"policy": "minimum"}'
 
 # Set per-node policy override
-curl -X POST http://127.0.0.1:8080/v1/stake_strategy \
+curl -X POST http://127.0.0.1:8080/v1/elections/settings \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $TOKEN" \
   -d '{"policy": {"fixed": 500000000000}, "node": "node0"}'
+
+# Update elections tick interval and max factor in one call
+curl -X POST http://127.0.0.1:8080/v1/elections/settings \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"tick_interval": 60, "max_factor": 2.5}'
+
+# Replace TON HTTP API endpoint list
+curl -X POST http://127.0.0.1:8080/v1/ton-http-api \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"urls": ["https://toncenter.com/api/v2/jsonRpc"]}'
+
+# Add a wallet
+curl -X POST http://127.0.0.1:8080/v1/wallets \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"name": "wallet0", "secret": "wallet0-key", "version": "V3R2", "subwallet_id": 42, "workchain": -1}'
 
 # Control elections task
 curl -X POST http://127.0.0.1:8080/v1/task/elections \

--- a/src/node-control/commands/Cargo.toml
+++ b/src/node-control/commands/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "commands"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = 'GPL-3.0'
 

--- a/src/node-control/common/Cargo.toml
+++ b/src/node-control/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "common"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = 'GPL-3.0'
 

--- a/src/node-control/contracts/Cargo.toml
+++ b/src/node-control/contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contracts"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = 'GPL-3.0'
 

--- a/src/node-control/control-client/Cargo.toml
+++ b/src/node-control/control-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "control-client"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = 'GPL-3.0'
 

--- a/src/node-control/docs/nodectl-security.md
+++ b/src/node-control/docs/nodectl-security.md
@@ -98,11 +98,19 @@ Cannot:
 Can:
 
 - everything `nominator` can do;
-- perform operational REST changes:
-  - `/v1/elections/exclude`
-  - `/v1/elections/include`
-  - `/v1/stake_strategy`
-  - `/v1/task/elections`
+- perform elections control:
+  - `POST /v1/elections/exclude`
+  - `POST /v1/elections/include`
+  - `POST /v1/elections/settings` (unified: stake policy, per-node overrides, `tick_interval`, `max_factor`)
+  - `POST /v1/task/elections`
+- manage configuration entities via REST:
+  - `POST /v1/nodes`, `DELETE /v1/nodes/{name}`
+  - `POST /v1/wallets`, `DELETE /v1/wallets/{name}`
+  - `POST /v1/pools`, `DELETE /v1/pools/{name}`
+  - `POST /v1/bindings`, `DELETE /v1/bindings/{node}`
+- update service settings via REST:
+  - `POST /v1/ton-http-api`
+  - `POST /v1/log`
 - view users list (`GET /auth/users`).
 
 Cannot:

--- a/src/node-control/docs/nodectl-setup.md
+++ b/src/node-control/docs/nodectl-setup.md
@@ -8,21 +8,23 @@ This guide provides step-by-step instructions for deploying and configuring **no
 - [Step 1: Install nodectl](#step-1-install-nodectl)
 - [Step 2: Configure SecretsVault](#step-2-configure-secretsvault)
 - [Step 3: Create nodectl Configuration](#step-3-create-nodectl-configuration)
-- [Step 4: Configure TON HTTP API](#step-4-configure-ton-http-api)
-- [Step 5: Create Secrets in Vault](#step-5-create-secrets-in-vault)
-- [Step 6: Master Wallet](#step-6-master-wallet)
-- [Step 7: Add Nodes](#step-7-add-nodes)
-- [Step 8: Add Wallets](#step-8-add-wallets)
-- [Step 9: Add Pools](#step-9-add-pools)
-- [Step 10: Configure Control Server Client Keys](#step-10-configure-control-server-client-keys)
-- [Step 11: Create Bindings](#step-11-create-bindings)
-- [Step 12: Configure Logging](#step-12-configure-logging)
-- [Step 13: Increase non-swap memory limits](#step-13-increase-non-swap-memory-limits)
-- [Step 14: Run the Service](#step-14-run-the-service)
-- [Step 15: Enable Elections](#step-15-enable-elections)
-- [Step 16: Configure REST API Authentication](#step-16-configure-rest-api-authentication)
+- [Step 4: Create Secrets in Vault](#step-4-create-secrets-in-vault)
+- [Step 5: Configure Logging](#step-5-configure-logging)
+- [Step 6: Increase non-swap memory limits](#step-6-increase-non-swap-memory-limits)
+- [Step 7: Run the Service](#step-7-run-the-service)
+- [Step 8: Configure REST API Authentication](#step-8-configure-rest-api-authentication)
+- [Step 9: Configure TON HTTP API](#step-9-configure-ton-http-api)
+- [Step 10: Master Wallet](#step-10-master-wallet)
+- [Step 11: Add Nodes](#step-11-add-nodes)
+- [Step 12: Add Wallets](#step-12-add-wallets)
+- [Step 13: Add Pools](#step-13-add-pools)
+- [Step 14: Configure Control Server Client Keys](#step-14-configure-control-server-client-keys)
+- [Step 15: Create Bindings](#step-15-create-bindings)
+- [Step 16: Enable Elections](#step-16-enable-elections)
 - [Security Recommendations](#security-recommendations)
 - [Troubleshooting](#troubleshooting)
+
+> **Important:** Starting with v0.4.0 all configuration mutations (`config node|wallet|pool|bind|elections|log|ton-http-api|master-wallet`) are REST clients that talk to a running `nodectl` daemon over JWT-authenticated endpoints. The steps below are ordered accordingly: start the service (Step 7) and create an operator user (Step 8) **before** issuing any `config` mutation. Only `config generate` still writes to disk directly.
 
 ---
 
@@ -44,7 +46,7 @@ Before starting the deployment, ensure you have:
 nodectl is distributed as a Docker image. Pull the latest version:
 
 ```bash
-docker pull ghcr.io/rsquad/ton-rust-node/nodectl:v0.1.1
+docker pull ghcr.io/rsquad/ton-rust-node/nodectl:v0.4.0
 ```
 
 To run any `nodectl` CLI command, use `docker run` with the image:
@@ -54,7 +56,7 @@ docker run --rm \
   -v "$(pwd)/nodectl-config.json":/nodectl/config.json \
   -e VAULT_URL="$VAULT_URL" \
   -e CONFIG_PATH="/nodectl/config.json" \
-  ghcr.io/rsquad/ton-rust-node/nodectl:v0.1.1 \
+  ghcr.io/rsquad/ton-rust-node/nodectl:v0.4.0 \
   nodectl <command> [options]
 ```
 
@@ -65,7 +67,7 @@ alias nodectl='docker run --rm \
   -v "$(pwd)/nodectl-config.json":/nodectl/config.json \
   -e VAULT_URL="$VAULT_URL" \
   -e CONFIG_PATH="/nodectl/config.json" \
-  ghcr.io/rsquad/ton-rust-node/nodectl:v0.1.1 \
+  ghcr.io/rsquad/ton-rust-node/nodectl:v0.4.0 \
   nodectl'
 ```
 
@@ -76,7 +78,7 @@ alias nodectl='docker run --rm \
 >   -v "$(pwd)/vault.json":/nodectl/vault.json \
 >   -e VAULT_URL="file:///nodectl/vault.json?master_key=$MASTER_KEY" \
 >   -e CONFIG_PATH="/nodectl/config.json" \
->   ghcr.io/rsquad/ton-rust-node/nodectl:v0.1.1 \
+>   ghcr.io/rsquad/ton-rust-node/nodectl:v0.4.0 \
 >   nodectl'
 > ```
 
@@ -157,43 +159,15 @@ nodectl config generate -o /nodectl/config.json
 
 The `-o /nodectl/config.json` flag writes the config to the path mounted by the Docker alias. Without it, `nodectl config generate` would write to `nodectl-config.json` inside the ephemeral container and the file would be lost on exit.
 
-> **Note:** All subsequent `nodectl config` commands accept `-c <path>` (or `--config <path>`) to specify the config file. Default is `nodectl-config.json`. You can also set the `CONFIG_PATH` environment variable.
+The generated config contains a default `ton_http_api` endpoint (`http://127.0.0.1:3301/`), default `elections`, `http` (with auth enabled and no users), `log`, and `master_wallet` sections. You will update the service-managed parts later via REST (Steps 9–16); the pre-service steps (4–6) only touch the vault and the local config file directly.
+
+> **Note:** Most `nodectl config` subcommands accept `-c <path>` (or `--config <path>`) to specify the configuration file from which the service URL (`http.bind`) is resolved. Default is `nodectl-config.json`. You can also set the `CONFIG_PATH` environment variable.
 
 ---
 
-## Step 4: Configure TON HTTP API
+## Step 4: Create Secrets in Vault
 
-nodectl needs access to the TON blockchain to read on-chain data (elections, validator sets, account states). It connects through the JSON RPC server running on a TON fullnode.
-
-Set the RPC server URL:
-
-```bash
-nodectl config ton-http-api set -u "http://127.0.0.1:3301/"
-```
-
-With an optional API key:
-
-```bash
-nodectl config ton-http-api set -u "http://127.0.0.1:3301/" -k "your-api-key"
-```
-
-> **Important**: Do not enable the RPC server on a validator node. Use a separate TON fullnode as the RPC server.
-
-Make sure the TON node's `config.json` has the RPC server enabled:
-
-```json
-{
-    "json_rpc_server": {
-        "address": "127.0.0.1:3301"
-    }
-}
-```
-
----
-
-## Step 5: Create Secrets in Vault
-
-Before configuring the master wallet, nodes, wallets, and pools, create all required cryptographic keys in the vault. These keys will be referenced by name in subsequent configuration steps.
+Create all required cryptographic keys in the vault **before** starting the service. These keys are referenced by name in later steps.
 
 Make sure the `VAULT_URL` environment variable is set (see [Step 2](#step-2-configure-secretsvault)).
 
@@ -237,234 +211,20 @@ The output shows the name, algorithm, extractable flag, creation date, and **pub
 
 ---
 
-## Step 6: Master Wallet
+## Step 5: Configure Logging
 
-The **master wallet** is a central funding source that the service uses to:
-
-- Automatically deploy validator wallets and nominator pools
-- Periodically top up validator wallets when their balance drops below the threshold (5 TON)
-
-When you created the configuration file in [Step 3](#step-3-create-nodectl-configuration), a `master_wallet` section was included automatically. The `key.name` field contains the vault secret name — this key was created in [Step 5](#step-5-create-secrets-in-vault).
-
-View master wallet information:
-
-```bash
-nodectl config master-wallet info
-```
-
-This shows the wallet address, balance, state, and public key.
-
-**Fund the master wallet address** with enough TON to cover deployment costs and ongoing wallet top-ups. Each wallet/pool deployment costs ~1 TON, and the service sends 10 TON when topping up wallets.
-
-> **Important:** Keep the master wallet balance above 10 TON. The service will periodically check balances and send top-ups from the master wallet automatically, but it cannot fund itself.
-
----
-
-## Step 7: Add Nodes
-
-Add each TON validator node to the configuration. For each node you need three things:
-
-- **Control Server endpoint** — the IP address and port where the node's Control Server is listening (e.g. `192.168.1.10:3031`). You can find this in the node's `config.json` under `control_server.address`.
-- **Control Server public key** — the server's public key in Base64 format. You can find it in the node's `config.json` under `control_server.server_key` (derive the public key from the private key, or use the key provided during node setup).
-- **Client secret name** — the name of the vault secret for the ADNL client private key. This key was created in [Step 5](#step-5-create-secrets-in-vault). Use the same name you chose there (e.g. `control-client-secret`).
-
-```bash
-nodectl config node add \
-    -n node1 \
-    -e "192.168.1.10:3031" \
-    -p "BK6eLCiiIvKKBH3qCZ7tX1in3UDdfYMBitmUKUbf36M=" \
-    -s "control-client-secret"
-```
-
-**Options:**
-
-| Option | Description |
-|--------|-------------|
-| `-n, --name` | Unique node name |
-| `-e, --control-server-endpoint` | Control Server address (IP:PORT) |
-| `-p, --control-server-pubkey` | Control Server public key (Base64) |
-| `-s, --control-client-secret-name` | Vault secret name for ADNL client private key |
-
-All nodes can share the same client key secret name (e.g. `control-client-secret`) — a single ADNL key can authenticate with multiple nodes.
-
-Repeat for each node:
-
-```bash
-nodectl config node add -n node2 -e "192.168.1.11:3031" -p "<SERVER_PUBKEY_BASE64>" -s "control-client-secret"
-nodectl config node add -n node3 -e "192.168.1.12:3031" -p "<SERVER_PUBKEY_BASE64>" -s "control-client-secret"
-```
-
-List configured nodes:
-
-```bash
-nodectl config node ls
-```
-
----
-
-## Step 8: Add Wallets
-
-Add a validator wallet for each node. Each wallet needs a unique name and a vault secret name for its private key. The key was created in [Step 5](#step-5-create-secrets-in-vault).
-
-```bash
-nodectl config wallet add -n wallet1 -s "wallet1-secret"
-```
-
-**Options:**
-
-| Option | Description |
-|--------|-------------|
-| `-n, --name` | Unique wallet name |
-| `-s, --secret-name` | Vault secret name for wallet private key |
-| `-v, --version` | Wallet version: `V3R2` (default), `V4R2`, `V5R1` |
-| `-w, --workchain` | Workchain ID (default: `-1`) |
-| `-i, --subwallet-id` | Subwallet ID (default: `42`) |
-
-Example for multiple nodes:
-
-```bash
-nodectl config wallet add -n wallet1 -s "wallet1-secret"
-nodectl config wallet add -n wallet2 -s "wallet2-secret"
-nodectl config wallet add -n wallet3 -s "wallet3-secret"
-```
-
-List configured wallets:
-
-```bash
-nodectl config wallet ls
-```
-
----
-
-## Step 9: Add Pools
-
-Nominator pools are configured in two ways:
-
-1. **`config pool add`** — **Single Nominator Pool (SNP)** — classic single-nominator contract (`kind: "snp"` in JSON).
-2. **`config pool add core`** — **TONCore nominator** — one or two on-chain pool contracts for even/odd rounds (`kind: "core"`, `pools: [slot0, slot1]`). Use **`add core`** only for TONCore; SNP stays on **`pool add`**.
-
-### SNP (default for simple setups)
-
-Add a Single Nominator Pool for each validator:
-
-```bash
-nodectl config pool add -n pool1 -o "0:bd313e9e1114bbbe7af6f28ef59be0ff3f02ac795423f10397a70dc16396c4ea"
-```
-
-**Options (`config pool add`):**
-
-| Option | Description |
-|--------|-------------|
-| `-n, --name` | Unique pool name |
-| `-o, --owner` | Owner address (nominator address) |
-| `-a, --address` | Pool contract address (if already deployed) |
-
-Example for multiple pools:
-
-```bash
-nodectl config pool add -n pool1 -o "0:<OWNER_ADDRESS_1>"
-nodectl config pool add -n pool2 -o "0:<OWNER_ADDRESS_2>"
-nodectl config pool add -n pool3 -o "0:<OWNER_ADDRESS_3>"
-```
-
-### TONCore
-
-Use **`nodectl config pool add core`** with one explicit slot flag per call: **`--even`** for slot 0 or **`--odd`** for slot 1, plus either `--validator-share` (deploy params) or `--address` (already deployed). Configure two slots with two separate commands using the same pool name.
-
-List configured pools:
-
-```bash
-nodectl config pool ls
-```
-
----
-
-## Step 10: Configure Control Server Client Keys
-
-Now that the control client key is created, you need to register its public key on each TON node. This allows nodectl to authenticate and send commands to the nodes.
-
-### 10.1 Get the Client Public Key
-
-Run the following command and find the row with your control client secret name (e.g. `control-client-secret`):
-
-```bash
-nodectl key ls
-```
-
-Copy the **Public Key** value (Base64-encoded).
-
-### 10.2 Add Client Key to Node Config
-
-In each TON node's configuration file (`config.json`), add the client public key to the `clients` list inside the `control_server` section:
+Logging is configured via the `log` section of the config file. Edit `nodectl-config.json` directly **before** starting the service — log rotation, level, and output mode are applied at service startup:
 
 ```json
 {
-  "control_server": {
-    "address": "0.0.0.0:3031",
-    "server_key": {
-      "type_id": 1209251014,
-      "pvt_key": "<SERVER_PRIVATE_KEY_BASE64>"
-    },
-    "clients": {
-      "list": [
-        {
-          "type_id": 1209251014,
-          "pub_key": "<CLIENT_PUBLIC_KEY_BASE64>"
-        }
-      ]
-    }
+  "log": {
+    "level": "INFO",
+    "output": "all",
+    "path": "./logs/nodectl.log",
+    "max_size_mb": 50,
+    "max_files": 10,
+    "rotation": "daily"
   }
-}
-```
-
-Replace `<CLIENT_PUBLIC_KEY_BASE64>` with the public key obtained from `nodectl key ls`.
-
-If you use the same client secret for all nodes, the same public key goes into every node's config. `type_id` is always `1209251014` (Ed25519).
-
-Restart each TON node after modifying its `config.json`.
-
----
-
-## Step 11: Create Bindings
-
-Bindings connect a node to its wallet and (optionally) a pool. This tells the service which wallet and pool to use for elections on each node.
-
-```bash
-nodectl config bind add -n node1 -w wallet1 -p pool1
-nodectl config bind add -n node2 -w wallet2 -p pool2
-nodectl config bind add -n node3 -w wallet3 -p pool3
-```
-
-**Options:**
-
-| Option | Description |
-|--------|-------------|
-| `-n, --node` | Node name (must exist in config) |
-| `-w, --wallet` | Wallet name (must exist in config) |
-| `-p, --pool` | Pool name (optional, must exist in config) |
-
-List all bindings:
-
-```bash
-nodectl config bind ls
-```
-
----
-
-## Step 12: Configure Logging
-
-Logging is configured directly in the config file under the `log` section:
-
-```json
-{
-    "log": {
-        "level": "INFO",
-        "output": "all",
-        "path": "./logs/nodectl.log",
-        "max_size_mb": 50,
-        "max_files": 10,
-        "rotation": "daily"
-    }
 }
 ```
 
@@ -481,20 +241,22 @@ Logging is configured directly in the config file under the `log` section:
 
 ```json
 {
-    "log": {
-        "level": "INFO",
-        "output": "all",
-        "path": "/var/log/nodectl/service.log",
-        "max_size_mb": 100,
-        "max_files": 20,
-        "rotation": "daily"
-    }
+  "log": {
+    "level": "INFO",
+    "output": "all",
+    "path": "/var/log/nodectl/service.log",
+    "max_size_mb": 100,
+    "max_files": 20,
+    "rotation": "daily"
+  }
 }
 ```
 
+After the service is running, logging settings can also be updated via REST with `nodectl config log set ...` (see [README Commands](../README.md#config-log)); the service picks up the change on the next tick without a restart.
+
 ---
 
-## Step 13: Increase non-swap memory limits
+## Step 6: Increase non-swap memory limits
 
 ### Configuring Locked Memory Limit
 
@@ -537,7 +299,9 @@ Expected output: `4194304`
 
 ---
 
-## Step 14: Run the Service
+## Step 7: Run the Service
+
+Start the nodectl service. The service hosts the REST API that all subsequent `config` subcommands talk to.
 
 ```bash
 # Create logs directory if it doesn't exist
@@ -550,7 +314,7 @@ docker run -d \
   -e VAULT_URL="$VAULT_URL" \
   -e CONFIG_PATH="/nodectl/config.json" \
   -e RUST_BACKTRACE=1 \
-  ghcr.io/rsquad/ton-rust-node/nodectl:v0.1.1 \
+  ghcr.io/rsquad/ton-rust-node/nodectl:v0.4.0 \
   nodectl service --config=/nodectl/config.json
 ```
 
@@ -564,7 +328,7 @@ docker run -d \
 >   -e VAULT_URL="file:///nodectl/vault.json?master_key=$MASTER_KEY" \
 >   -e CONFIG_PATH="/nodectl/config.json" \
 >   -e RUST_BACKTRACE=1 \
->   ghcr.io/rsquad/ton-rust-node/nodectl:v0.1.1 \
+>   ghcr.io/rsquad/ton-rust-node/nodectl:v0.4.0 \
 >   nodectl service --config=/nodectl/config.json
 > ```
 > Without this mount, all vault keys (wallet keys, ADNL keys) will be lost on every container restart.
@@ -573,34 +337,379 @@ docker run -d \
 
 Once started, the service:
 
-1. **Hot-reloads configuration** — checks the config file every **10 seconds** and applies changes without restart. You can edit the config or use `nodectl config` commands while the service is running.
+1. **Serves the REST API** on `http.bind` (default `0.0.0.0:8080`). All subsequent configuration commands (nodes, wallets, pools, bindings, elections settings, logging, TON HTTP API) flow through this API. Protected endpoints require a JWT token — see [Step 8](#step-8-configure-rest-api-authentication).
 
 2. **Auto-deploys contracts** — automatically deploys validator wallets and nominator pools that are configured but not yet deployed on-chain. Deployment is funded from the master wallet.
 
 3. **Auto-funds wallets** — periodically checks validator wallet balances and sends **10 TON** from the master wallet when a wallet balance drops below **5 TON**.
 
-> **Important:** Keep the master wallet address funded. If its balance drops below 10 TON, the service will not be able to top up validator wallets or deploy new contracts. Monitor it with `nodectl config master-wallet info`.
+4. **Runs the elections task** — participates in validator elections according to the configured stake policy for every enabled binding (see [Step 16](#step-16-enable-elections)).
+
+> **Important:** Keep the master wallet address funded. If its balance drops below 10 TON, the service will not be able to top up validator wallets or deploy new contracts. Monitor it with `nodectl config master-wallet info` (after Step 8).
 
 ---
 
-## Step 15: Enable Elections
+## Step 8: Configure REST API Authentication
+
+**Authentication is enabled by default.** The generated config includes the `http.auth` section with an empty user list — all protected endpoints return `401` until at least one user is created. The `/health` endpoint remains public.
+
+On first start the service automatically creates a JWT signing key in the vault (secret `auth.jwt-signing-key`).
+
+**No service restart is required** to change authentication settings. The service hot-reloads the configuration, so creating the first user with `nodectl auth add` makes the API accessible immediately.
+
+> For a detailed description of roles, token lifecycle, revocation, rate limiting, and monitoring, see the **[Security Guide](./nodectl-security.md)**.
+
+### 8.1 Create Users
+
+Use `nodectl auth add` to create users. The password is entered interactively (or from stdin with `--password-stdin`). `nodectl auth` commands write directly to the config file and vault — they do not require the service to answer REST requests.
+
+```bash
+# Create an operator user (full operational access)
+nodectl auth add --username operator --role operator
+
+# Create a nominator user (read-only access)
+nodectl auth add --username viewer --role nominator
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--username` | Username (alphanumeric, `_`, `-`, max 64 chars) |
+| `--role` | User role: `operator` or `nominator` |
+| `--password-stdin` | Read password from stdin (no confirmation prompt) |
+
+Password hashes are stored in the vault (secret name: `auth.users.<username>`).
+
+### 8.2 List Users
+
+```bash
+nodectl auth ls
+```
+
+### 8.3 Configure Token TTL
+
+```bash
+nodectl auth set ttl --operator 720h --nominator 24h
+```
+
+Values accept seconds (`3600`), or duration suffixes (`30s`, `60m`, `8h`).
+
+### 8.4 Log In to the REST API
+
+All `nodectl api` and `nodectl config` commands resolve the service URL in this order:
+
+1. Explicit `--url` (`-u`) flag (or `NODECTL_URL` env var for `config`).
+2. `http.bind` value from `--config` (or `CONFIG_PATH`).
+
+If neither is available, the command fails. When running on the same host as the service, the config file is usually present and the URL is resolved automatically. When connecting from a remote machine, pass `--url` explicitly:
+
+```bash
+# Local — URL from config
+nodectl api login operator
+
+# Remote — explicit URL
+nodectl api login operator -u http://192.168.1.10:8080
+```
+
+> **Warning:** nodectl serves plain HTTP. If you connect from outside the host, terminate TLS at a reverse proxy or SSH tunnel — otherwise the password and JWT token travel in plain text.
+
+The command prints the JWT token, its expiration, and the user role. Export the token so subsequent REST commands pick it up automatically:
+
+```bash
+export NODECTL_API_TOKEN="<token from login>"
+```
+
+Once the token is exported, all `nodectl api` and `nodectl config` commands use it automatically:
+
+```bash
+nodectl api elections
+nodectl api validators
+nodectl api task elections restart
+```
+
+---
+
+## Step 9: Configure TON HTTP API
+
+nodectl needs access to the TON blockchain to read on-chain data (elections, validator sets, account states). It connects through the JSON-RPC server running on a TON fullnode.
+
+The generated config already points at `http://127.0.0.1:3301/`. If your RPC server runs elsewhere or requires an API key, update it via REST:
+
+```bash
+# Replace the endpoint list with a single URL
+nodectl config ton-http-api set -e "http://127.0.0.1:3301/"
+
+# Replace with an endpoint + API key
+nodectl config ton-http-api set -e "http://127.0.0.1:3301/" -k "your-api-key"
+
+# Append a failover endpoint (does not remove existing ones)
+nodectl config ton-http-api add -e "https://backup-endpoint/api/v2/jsonRpc"
+```
+
+> **Important**: Do not enable the RPC server on a validator node. Use a separate TON fullnode as the RPC server.
+
+Make sure the TON node's `config.json` has the RPC server enabled:
+
+```json
+{
+  "json_rpc_server": {
+    "address": "127.0.0.1:3301"
+  }
+}
+```
+
+---
+
+## Step 10: Master Wallet
+
+The **master wallet** is a central funding source that the service uses to:
+
+- Automatically deploy validator wallets and nominator pools
+- Periodically top up validator wallets when their balance drops below the threshold (5 TON)
+
+When you generated the configuration file in [Step 3](#step-3-create-nodectl-configuration), a `master_wallet` section was included automatically. The `key.name` field contains the vault secret name — this key was created in [Step 4](#step-4-create-secrets-in-vault).
+
+View master wallet information:
+
+```bash
+nodectl config master-wallet info
+```
+
+This shows the wallet address, balance, state, and public key.
+
+**Fund the master wallet address** with enough TON to cover deployment costs and ongoing wallet top-ups. Each wallet/pool deployment costs ~1 TON, and the service sends 10 TON when topping up wallets.
+
+> **Important:** Keep the master wallet balance above 10 TON. The service will periodically check balances and send top-ups from the master wallet automatically, but it cannot fund itself.
+
+---
+
+## Step 11: Add Nodes
+
+Add each TON validator node to the configuration. For each node you need three things:
+
+- **Control Server endpoint** — the IP address and port where the node's Control Server is listening (e.g. `192.168.1.10:3031`). You can find this in the node's `config.json` under `control_server.address`.
+- **Control Server public key** — the server's public key in Base64 format. You can find it in the node's `config.json` under `control_server.server_key` (derive the public key from the private key, or use the key provided during node setup).
+- **Client secret name** — the name of the vault secret for the ADNL client private key. This key was created in [Step 4](#step-4-create-secrets-in-vault). Use the same name you chose there (e.g. `control-client-secret`).
+
+```bash
+nodectl config node add \
+    -n node1 \
+    -e "192.168.1.10:3031" \
+    -p "BK6eLCiiIvKKBH3qCZ7tX1in3UDdfYMBitmUKUbf36M=" \
+    -s "control-client-secret"
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `-n, --name` | Unique node name |
+| `-e, --control-server-endpoint` | Control Server address (IP:PORT) |
+| `-p, --control-server-pubkey` | Control Server public key (Base64) |
+| `-s, --control-client-secret-name` | Vault secret name for ADNL client private key |
+
+All nodes can share the same client key secret name (e.g. `control-client-secret`) — a single ADNL key can authenticate with multiple nodes.
+
+Repeat for each node:
+
+```bash
+nodectl config node add -n node2 -e "192.168.1.11:3031" -p "<SERVER_PUBKEY_BASE64>" -s "control-client-secret"
+nodectl config node add -n node3 -e "192.168.1.12:3031" -p "<SERVER_PUBKEY_BASE64>" -s "control-client-secret"
+```
+
+List configured nodes:
+
+```bash
+nodectl config node ls
+```
+
+---
+
+## Step 12: Add Wallets
+
+Add a validator wallet for each node. Each wallet needs a unique name and a vault secret name for its private key. The key was created in [Step 4](#step-4-create-secrets-in-vault).
+
+```bash
+nodectl config wallet add -n wallet1 -s "wallet1-secret"
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `-n, --name` | Unique wallet name |
+| `-s, --secret-name` | Vault secret name for wallet private key |
+| `-v, --version` | Wallet version: `V3R2` (default), `V4R2`, `V5R1` |
+| `-w, --workchain` | Workchain ID (default: `-1`) |
+| `-i, --subwallet-id` | Subwallet ID (default: `42`) |
+
+Example for multiple nodes:
+
+```bash
+nodectl config wallet add -n wallet1 -s "wallet1-secret"
+nodectl config wallet add -n wallet2 -s "wallet2-secret"
+nodectl config wallet add -n wallet3 -s "wallet3-secret"
+```
+
+List configured wallets:
+
+```bash
+nodectl config wallet ls
+```
+
+---
+
+## Step 13: Add Pools
+
+Nominator pools are configured in two ways:
+
+1. **`config pool add`** — **Single Nominator Pool (SNP)** — classic single-nominator contract (`kind: "snp"` in JSON).
+2. **`config pool add core`** — **TONCore nominator** — one or two on-chain pool contracts for even/odd rounds (`kind: "core"`, `pools: [slot0, slot1]`). Use **`add core`** only for TONCore; SNP stays on **`pool add`**.
+
+Both commands go through the REST API on the running service.
+
+### SNP
+
+Add a Single Nominator Pool for each validator:
+
+```bash
+nodectl config pool add -n pool1 -o "0:bd313e9e1114bbbe7af6f28ef59be0ff3f02ac795423f10397a70dc16396c4ea"
+```
+
+**Options (`config pool add`):**
+
+| Option | Description |
+|--------|-------------|
+| `-n, --name` | Unique pool name |
+| `-o, --owner` | Owner address (nominator address) |
+| `-a, --address` | Pool contract address (if already deployed) |
+
+At least one of `--address` or `--owner` is required.
+
+Example for multiple pools:
+
+```bash
+nodectl config pool add -n pool1 -o "0:<OWNER_ADDRESS_1>"
+nodectl config pool add -n pool2 -o "0:<OWNER_ADDRESS_2>"
+nodectl config pool add -n pool3 -o "0:<OWNER_ADDRESS_3>"
+```
+
+### TONCore
+
+Configure the even and/or odd slot with `config pool add core` — one explicit slot flag per call (`--even` or `--odd`) plus either deploy params (`--validator-share`, optionally `--max-nominators`, `--min-validator-stake`, `--min-nominator-stake`) or `--address` of an already-deployed pool. Configure two slots with two separate commands that share the same `--name`.
+
+```bash
+# Slot 0 (even): deploy params
+nodectl config pool add core -n pool1 --validator-share 5000 --even
+
+# Slot 1 (odd): deploy params
+nodectl config pool add core -n pool1 --validator-share 5000 --odd
+
+# Existing deployment: pass --address instead of --validator-share
+nodectl config pool add core -n pool1 --address "-1:..." --even
+```
+
+`validator-share` is in basis points (e.g. `5000` = 50%). `min-validator-stake` / `min-nominator-stake` accept TON amounts.
+
+List configured pools:
+
+```bash
+nodectl config pool ls
+```
+
+---
+
+## Step 14: Configure Control Server Client Keys
+
+Now that the control client key is created, you need to register its public key on each TON node. This allows nodectl to authenticate and send commands to the nodes.
+
+### 14.1 Get the Client Public Key
+
+Run the following command and find the row with your control client secret name (e.g. `control-client-secret`):
+
+```bash
+nodectl key ls
+```
+
+Copy the **Public Key** value (Base64-encoded).
+
+### 14.2 Add Client Key to Node Config
+
+In each TON node's configuration file (`config.json`), add the client public key to the `clients` list inside the `control_server` section:
+
+```json
+{
+  "control_server": {
+    "address": "0.0.0.0:3031",
+    "server_key": {
+      "type_id": 1209251014,
+      "pvt_key": "<SERVER_PRIVATE_KEY_BASE64>"
+    },
+    "clients": {
+      "list": [
+        {
+          "type_id": 1209251014,
+          "pub_key": "<CLIENT_PUBLIC_KEY_BASE64>"
+        }
+      ]
+    }
+  }
+}
+```
+
+Replace `<CLIENT_PUBLIC_KEY_BASE64>` with the public key obtained from `nodectl key ls`.
+
+If you use the same client secret for all nodes, the same public key goes into every node's config. `type_id` is always `1209251014` (Ed25519).
+
+Restart each TON node after modifying its `config.json`.
+
+---
+
+## Step 15: Create Bindings
+
+Bindings connect a node to its wallet and (optionally) a pool. This tells the service which wallet and pool to use for elections on each node.
+
+```bash
+nodectl config bind add -n node1 -w wallet1 -p pool1
+nodectl config bind add -n node2 -w wallet2 -p pool2
+nodectl config bind add -n node3 -w wallet3 -p pool3
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `-n, --node` | Node name (must exist in config) |
+| `-w, --wallet` | Wallet name (must exist in config) |
+| `-p, --pool` | Pool name (optional, must exist in config) |
+
+List all bindings:
+
+```bash
+nodectl config bind ls
+```
+
+---
+
+## Step 16: Enable Elections
 
 By default, elections participation is **disabled** for all bindings. You must explicitly enable it.
 
-### 15.1 Enable Elections
+### 16.1 Enable Elections
 
 ```bash
 # Enable elections for specific bindings (by node name)
 nodectl config elections enable node1 node2 node3
 ```
 
-### 15.2 Disable Elections
+### 16.2 Disable Elections
 
 ```bash
 nodectl config elections disable node1
 ```
 
-### 15.3 View Election Status
+### 16.3 View Election Status
 
 ```bash
 nodectl config elections show
@@ -612,7 +721,7 @@ Use `--format json` for machine-readable output:
 nodectl config elections show --format json
 ```
 
-### 15.4 Binding Statuses
+### 16.4 Binding Statuses
 
 Each binding has a `status` field that the service manages automatically. The following statuses exist:
 
@@ -635,17 +744,20 @@ validating -> idle           (node leaves the validator set, no pending recovery
 
 The service updates binding statuses in the config file automatically. You can observe them via `nodectl config elections show` or by inspecting the config file directly.
 
-### 15.5 Configure Stake Policy
+### 16.5 Configure Stake Policy
 
 ```bash
 # Minimum required stake
 nodectl config elections stake-policy --minimum
 
-# Fixed amount in TON
-nodectl config elections stake-policy --fixed 100
-
 # Split available balance 50/50 (default)
 nodectl config elections stake-policy --split50
+
+# Adaptive split (half when above Elector threshold, otherwise stake all)
+nodectl config elections stake-policy --adaptive-split50
+
+# Fixed amount in TON
+nodectl config elections stake-policy --fixed 100
 
 # Override policy for a specific node
 nodectl config elections stake-policy --fixed 50 -n node1
@@ -654,85 +766,7 @@ nodectl config elections stake-policy --fixed 50 -n node1
 nodectl config elections stake-policy --reset -n node1
 ```
 
----
-
-## Step 16: Configure REST API Authentication
-
-**Authentication is enabled by default.** A freshly generated config includes the `http.auth` section with an empty user list — all protected endpoints return `401` until at least one user is created. The `/health` endpoint remains accessible.
-
-On first start the service automatically creates a JWT signing key in the vault (secret `auth.jwt-signing-key`).
-
-**No service restart is required** to change authentication settings. The service hot-reloads the configuration, so creating the first user with `nodectl auth add` makes the API accessible immediately.
-
-> For a detailed description of roles, token lifecycle, revocation, rate limiting, and monitoring, see the **[Security Guide](./nodectl-security.md)**.
-
-### 16.1 Create Users
-
-Use `nodectl auth add` to create users. The password is entered interactively.
-
-```bash
-# Create an operator user (full operational access)
-nodectl auth add --username operator --role operator
-
-# Create a nominator user (read-only access)
-nodectl auth add --username viewer --role nominator
-```
-
-**Options:**
-
-| Option | Description |
-|--------|-------------|
-| `--username` | Username (alphanumeric, `_`, `-`, max 64 chars) |
-| `--role` | User role: `operator` or `nominator` |
-
-Password hashes are stored in the vault (secret name: `auth.users.<username>`).
-
-### 16.2 List Users
-
-```bash
-nodectl auth ls
-```
-
-### 16.3 Configure Token TTL
-
-```bash
-nodectl auth set ttl --operator 720h --nominator 24h
-```
-
-Values accept seconds (`3600`), or duration suffixes (`30s`, `60m`, `8h`).
-
-### 16.4 Log In to the REST API
-
-All `nodectl api` commands resolve the service URL in this order:
-
-1. Explicit `--url` (`-u`) flag
-2. `http.bind` value from `--config` (or `CONFIG_PATH`)
-
-If neither is available, the command fails. When running on the same host as the service, the config file is usually present and the URL is resolved automatically. When connecting from a remote machine, pass `--url` explicitly:
-
-```bash
-# Local — URL from config
-nodectl api login operator
-
-# Remote — explicit URL
-nodectl api login operator -u http://192.168.1.10:8080
-```
-
-> **Warning:** nodectl serves plain HTTP. If you connect from outside the host, terminate TLS at a reverse proxy or SSH tunnel — otherwise the password and JWT token travel in plain text.
-
-The command prints the JWT token, its expiration, and the user role. Store the token for subsequent API calls:
-
-```bash
-export NODECTL_API_TOKEN="<token from login>"
-```
-
-Once the token is exported, all `nodectl api` commands use it automatically:
-
-```bash
-nodectl api elections
-nodectl api validators
-nodectl api task elections restart
-```
+See [Staking Strategies](./staking-strategies.md) for an in-depth description of the `adaptive-split50` policy.
 
 ---
 

--- a/src/node-control/docs/staking-strategies.md
+++ b/src/node-control/docs/staking-strategies.md
@@ -72,10 +72,12 @@ On every tick after the initial submission, the strategy re-evaluates:
 
 ### Configuration
 
-| Parameter | Type | Description |
-|---|---|---|
-| `sleep_period` | float (0.0–1.0) | Fraction of election duration to wait before acting. |
-| `waiting_period` | float (0.0–1.0) | Max fraction of election duration to wait for participants. |
+The parameters below live under the `elections` section of `nodectl-config.json`.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `sleep_period_pct` | float (0.0–1.0) | `0.2` | Fraction of election duration to wait before acting. |
+| `waiting_period_pct` | float (0.0–1.0) | `0.4` | Max fraction of election duration to wait for participants. Must be ≥ `sleep_period_pct`. |
 
 ---
 

--- a/src/node-control/docs/staking-strategies.md
+++ b/src/node-control/docs/staking-strategies.md
@@ -1,28 +1,101 @@
 # Nodectl Staking Strategies
 
+nodectl picks a stake amount for every election round using a **stake policy**. Each binding resolves its effective policy by checking `elections.policy_overrides` first and falling back to `elections.policy`, so you can mix strategies across nodes in a single config.
+
+There are four strategies, configured via `config elections stake-policy` (or `POST /v1/elections/settings`):
+
+| Strategy | Config value | Amount staked per round |
+|---|---|---|
+| [Minimum](#minimum) | `"minimum"` | Chain's minimum participation stake |
+| [Fixed](#fixed) | `{ "fixed": <nanotons> }` | A constant amount, clamped to `[min_stake, available]` |
+| [Split50](#split50) | `"split50"` | Half of available balance, floored at `min_stake` |
+| [AdaptiveSplit50](#adaptivesplit50) | `"adaptive_split50"` | Half when competitive, otherwise all — estimates the Elector's selection threshold |
+
+All four are evaluated on every elections tick. If the resulting stake exceeds the free balance, the round is skipped with an error; if the current submission already covers the required stake, no additional message is sent.
+
+> **TONCore nominator caveat.** `Split50` and `AdaptiveSplit50` both assume a single pool can re-split its balance across alternating rounds. The TONCore nominator uses **two separate pools** (even / odd) that each stake in only one round, so splitting inside a round has no effect. When the binding points at a TONCore nominator, the runner ignores these two policies and stakes the **full liquid balance of the selected pool** (still floored at `min_stake`). To stake less, switch the binding (or the per-node override) to `Minimum` or `Fixed`.
+
+### Shared terms
+
+| Term | Description |
+|---|---|
+| **Elector** | TON smart contract that runs validator elections (`config param 1`). |
+| **min_stake** | Minimum stake accepted by the Elector for this round (from `config param 17` / election data). Hard floor for all strategies. |
+| **available** | Funds that can be staked: `frozen_stake + free_pool_balance + current_stake`. |
+| **current_stake** | Stake already submitted to the active election (0 if none). |
+
+---
+
+## Minimum
+
+Stakes exactly **`min_stake`** — the chain-enforced floor for participating in the round.
+
+```text
+stake = min_stake
+```
+
+**When to use.** Testing / small-balance setups, or when another process tops up the pool externally and you only want nodectl to keep a seat open with the smallest valid bid.
+
+**Trade-offs.** You always participate with the cheapest possible submission but have essentially no chance of being selected whenever competitors raise their stakes. Expect empty rounds on a busy network.
+
+---
+
+## Fixed
+
+Stakes a constant amount that you control, clamped to the legal range:
+
+```text
+stake = clamp(configured_amount, min_stake, available)
+```
+
+- If the configured amount is below `min_stake`, nodectl raises it to `min_stake`.
+- If it exceeds `available`, nodectl caps it at `available`.
+
+Configured in TON from the CLI (`--fixed <TON>`) and in nanotons via REST (`{"fixed": <nanotons>}`).
+
+**When to use.** You know exactly how much validator capital should be at risk per round and want deterministic accounting — for example, budgeting rewards per wallet or holding a cold reserve off-chain.
+
+**Trade-offs.** The amount does not react to competitors. Under-bid and you never validate; over-bid and you lock up capital that would have been as effective at a lower number.
+
+---
+
+## Split50
+
+Stakes half of the available balance, with `min_stake` as the floor:
+
+```text
+stake = max(available / 2, min_stake)
+```
+
+The intent is to keep two rounds worth of capital working at once: half goes into the current round while the other half is ready for the next.
+
+**When to use.** Default for most validator setups. Good steady-state behaviour when the balance comfortably exceeds `min_stake` and you want to validate every round.
+
+**Trade-offs.** Split50 does **not** estimate whether half will actually be selected by the Elector. On a crowded round where the effective selection threshold is above `available / 2`, you still stake half and then lose to higher bidders. AdaptiveSplit50 is the competitive-aware upgrade.
+
+**TONCore nominator.** Ignored on a TONCore binding — see the caveat in the intro. The runner stakes the full liquid balance of the selected pool (still ≥ `min_stake`).
+
+---
+
 ## AdaptiveSplit50
+
+Like Split50, but estimates the Elector's **minimum effective stake** (the amount actually required to win a seat this round) and falls back to staking the full available balance when half would not clear that bar.
 
 ### Overview
 
 AdaptiveSplit50 splits your funds in half and stakes each half into alternating election rounds, so capital is always working. If half is not enough to be selected by the Elector, it stakes everything into the current round instead.
 
----
-
 ### Key Terms
 
 | Term | Description |
 |---|---|
-| **Elector** | TON smart contract that runs validator elections. |
-| **min_eff_stake** | Minimum stake the Elector would accept. Below this — no rewards. |
+| **min_eff_stake** | Estimated minimum stake the Elector would **select** (not merely accept). Below this — no seat. |
 | **frozen_stake** | Stake locked in the previous validation round. |
 | **free_pool_balance** | Funds available for staking on the pool balance. |
-| **current_stake** | Stake already submitted to the current election (0 if none). |
 | **available** | `frozen_stake + free_pool_balance + current_stake` |
 | **half** | `available / 2` |
 | **sleep_period** | Minimum wait time (fraction of election duration) before acting. |
-| **waiting_period** | Maximum wait time for enough participants before using fallback data. Must be >= `sleep_period`. |
-
----
+| **waiting_period** | Maximum wait time for enough participants before using fallback data. Must be ≥ `sleep_period`. |
 
 ### How It Works
 
@@ -48,7 +121,7 @@ The strategy needs to know the minimum stake required to be selected. It uses tw
 
 #### 3. Decide how much to stake
 
-```
+```text
 available = frozen_stake + free_pool_balance + current_stake
 half = available / 2
 ```
@@ -68,8 +141,6 @@ On every tick after the initial submission, the strategy re-evaluates:
 - If `min_eff_stake` has risen above `current_stake` (e.g. larger stakes arrived), it tops up by the difference.
 - The same half-vs-all logic applies: if the remaining funds can't cover the next round, everything goes into the current one.
 
----
-
 ### Configuration
 
 The parameters below live under the `elections` section of `nodectl-config.json`.
@@ -79,11 +150,9 @@ The parameters below live under the `elections` section of `nodectl-config.json`
 | `sleep_period_pct` | float (0.0–1.0) | `0.2` | Fraction of election duration to wait before acting. |
 | `waiting_period_pct` | float (0.0–1.0) | `0.4` | Max fraction of election duration to wait for participants. Must be ≥ `sleep_period_pct`. |
 
----
-
 ### Decision Flowchart
 
-```
+```text
 Election starts
        │
        ▼
@@ -117,4 +186,36 @@ Election starts
   │                                                │
   │  Apply same half-vs-all logic                  │
   └────────────────────────────────────────────────┘
+```
+
+**When to use.** Production validators that want Split50's capital efficiency without losing rounds to rising competitor bids.
+
+**Trade-offs.**
+
+- **Needs an estimate of `min_eff_stake`.** The strategy relies on either (a) the Elector emulator running on the current round's participants or (b) the smallest frozen stake from the previous round. If neither is available — e.g. a brand-new chain's first election or a round with too few bidders before `waiting_period_pct` expires — the tick is skipped with an error and no stake is submitted.
+- **Delays the first submission.** Unlike `Split50`, AdaptiveSplit50 deliberately waits at least `sleep_period_pct` of the election duration before acting, so it can observe competitor bids. On very short election windows this leaves less time to react if the message fails and has to be retried.
+- **Extra on-chain messages for top-ups.** Every tick after the initial submission re-estimates `min_eff_stake`; if it has risen, the runner sends an additional stake message for the delta. Each top-up costs gas (`ELECTOR_STAKE_FEE + wallet/pool compute fees`). On a volatile round you may pay for several top-ups.
+- **Estimate can lag reality.** The emulator only sees stakes that have already been submitted. A late burst of large bids after your final submission can still push `min_eff_stake` above your accepted stake — AdaptiveSplit50 will chase on the next tick, but only while the round is still open.
+- **Requires `sleep_period_pct` / `waiting_period_pct` tuning** for networks with unusual election pacing. The defaults (0.2 / 0.4) assume standard TON mainnet cadence.
+
+**TONCore nominator.** Ignored on a TONCore binding — see the caveat in the intro. The adaptive emulator / top-up path is skipped and the runner stakes the full liquid balance of the selected pool (still ≥ `min_stake`).
+
+---
+
+## Choosing a strategy
+
+- **Default** — `Split50` is a reasonable starting point on a network where your balance is comfortably above `min_stake` and competitor bids are stable.
+- **Competitive network** — switch to `AdaptiveSplit50` once you have enough balance that "half" would matter; it reacts to live Elector pressure.
+- **Budgeted capital** — `Fixed` when you want predictable exposure per round regardless of free balance.
+- **Smoke tests / CI** — `Minimum` keeps bids at the legal floor.
+- **TONCore nominator binding** — use `Fixed` or `Minimum` if you need to cap per-round exposure. `Split50` and `AdaptiveSplit50` are accepted but collapse to "stake the full liquid balance of the selected pool" because the two TONCore pools can't both stake in the same round.
+
+Policies can be mixed per node via `policy_overrides`:
+
+```bash
+# Default for all nodes
+nodectl config elections stake-policy --adaptive-split50
+
+# But keep node0 on a conservative fixed bid
+nodectl config elections stake-policy --node node0 --fixed 10000
 ```

--- a/src/node-control/elections/Cargo.toml
+++ b/src/node-control/elections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elections"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = 'GPL-3.0'
 

--- a/src/node-control/nodectl/Cargo.toml
+++ b/src/node-control/nodectl/Cargo.toml
@@ -2,7 +2,7 @@
 build = '../../common/build/build.rs'
 name = "nodectl"
 description = "Tool for managing Rust TON node"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = 'GPL-3.0'
 

--- a/src/node-control/service/Cargo.toml
+++ b/src/node-control/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = 'GPL-3.0'
 

--- a/src/node-control/ton-http-api-client/Cargo.toml
+++ b/src/node-control/ton-http-api-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ton-http-api-client"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = 'GPL-3.0'
 

--- a/src/node/tests/test_load_net/scripts/create-proposal.ts
+++ b/src/node/tests/test_load_net/scripts/create-proposal.ts
@@ -1,4 +1,4 @@
-import { Address, beginCell, Cell, Dictionary, fromNano, toNano, TransactionDescriptionGeneric } from '@ton/core';
+import { Address, beginCell, Cell, Dictionary, fromNano, loadTransaction, toNano, TransactionDescriptionGeneric } from '@ton/core';
 import * as fs from 'fs';
 import { NetworkProvider, sleep } from "@ton/blueprint";
 import { TonClient, WalletContractV3R2 } from '@ton/ton';
@@ -41,7 +41,7 @@ export async function run(provider: NetworkProvider) {
     param11s.loadUint(8);
     const minStoreSec = param11s.loadUint(32);
     console.log(`minStoreSec (for critical params only): ${minStoreSec}`);
-    
+
     const expiresAt = now + parseInt(process.env.EXPIRES_IN_SECS ?? (await ui.input('Expires in seconds:')));
 
     for (const [name, param] of Object.entries(params)) {
@@ -105,11 +105,9 @@ export async function run(provider: NetworkProvider) {
 
         const state = await client.getContractState(configAddress);
         const { lt, hash } = state.lastTransaction!;
-        const transactions = await client.getTransactions(configAddress, {
-            limit: 10,
-            lt, hash,
-        });
-        for (const tx of transactions) {
+        const transactions = await getTransactions(configAddress, 10, parseInt(lt), hash);
+        for (const txCell of transactions) {
+            const tx = loadTransaction(Cell.fromBoc(Buffer.from(txCell.TransactionId.data, 'base64'))[0].beginParse());
             if (tx.inMessage! && tx.inMessage.info.src!.toString() === wallet.address.toString()) {
                 const description = tx.description as TransactionDescriptionGeneric;
                 console.log(`tx hash: ${tx.hash().toString('hex')}`);
@@ -180,17 +178,50 @@ async function proposalStoragePrice(
 }
 
 async function getConfig(id: number): Promise<Cell> {
-    const result = await fetch(`http://localhost/getConfigParam?config_id=${id}`, {
-        method: 'GET',
+    try {
+        const idx = process.argv.findIndex(arg => arg == '--custom');
+        const url = idx !== -1 ? process.argv[idx + 1] : 'http://127.0.0.1:3301';
+        const baseUrl = url.endsWith("jsonRPC") ? url.slice(0, -6) : url;
+        const normalizedUrl = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+        const result = await fetch(`${normalizedUrl}getConfigParam?config_id=${id}`, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+        const data = await result.json();
+        if (!data.ok) {
+            throw new Error(`Failed to get config: ${data.error}`);
+        }
+        return Cell.fromBase64(data.result.config.bytes as string);
+    } catch (error) {
+        console.error(`Failed to get config: ${error}`);
+        throw error;
+    }
+}
+
+async function getTransactions(address: Address, limit: number, lt: number, hash: string) {
+    const result = await fetch(`http://127.0.0.1:3301/jsonRPC`, {
+        method: 'POST',
         headers: {
             'Content-Type': 'application/json',
         },
+        body: JSON.stringify({
+            jsonrpc: '2.0',
+            method: 'getTransactions',
+            params: {
+                address: address.toString(),
+                limit,
+                lt,
+                hash,
+            },
+        }),
     });
     const data = await result.json();
     if (!data.ok) {
-        throw new Error(`Failed to get config: ${data.error}`);
+        throw new Error(`Failed to get transactions: ${data.error}`);
     }
-    return Cell.fromBase64(data.result.config.bytes as string);
+    return data.result;
 }
 
 function buildConfigParam15(param: any) {


### PR DESCRIPTION
Release prep for nodectl v0.4.0: bumps all node-control crates and the helm chart to 0.4.0, adds the CHANGELOG entry, and brings the README, security guide, setup guide, and staking-strategies doc in line with the v0.4.0 REST API, CLI, and stake-policy changes. Linear: SMA-73