### PR TITLE
feat(nodectl): TONCore per-slot details in 'config pool ls' + REST add

### DIFF
--- a/src/node-control/commands/src/commands/nodectl/config_pool_cmd.rs
+++ b/src/node-control/commands/src/commands/nodectl/config_pool_cmd.rs
@@ -281,6 +281,12 @@ impl PoolAddCoreCmd {
             anyhow::bail!("At least one of --address or --validator-share must be specified");
         }
 
+        if let Some(vs) = self.validator_share {
+            if !(0..=10_000).contains(&vs) {
+                anyhow::bail!("validator_share must be in 0..=10000 basis points (got {vs})");
+            }
+        }
+
         let slot_name = if self.odd { "odd" } else { "even" };
 
         // Validate locally so the user gets the standard "invalid TON address"

--- a/src/node-control/commands/src/commands/nodectl/config_pool_cmd.rs
+++ b/src/node-control/commands/src/commands/nodectl/config_pool_cmd.rs
@@ -335,10 +335,39 @@ struct PoolView {
     balance: Option<u64>,
     address: Option<String>,
     owner: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    addresses: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    validator_share: Option<u64>,
+    /// Per-slot data for TONCore pools; absent for SNP pools.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    slots: Option<Vec<TonCorePoolSlotView>>,
+}
+
+#[derive(Clone, Default, serde::Serialize, serde::Deserialize)]
+struct TonCorePoolSlotView {
+    /// "even" (slot 0) or "odd" (slot 1)
+    slot: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    address: Option<String>,
+    /// Account state: "active", "uninit", "frozen", "not deployed", or "error".
+    state: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    balance: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    validator_share: Option<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    max_nominators: Option<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    min_validator_stake: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    min_nominator_stake: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    nominators_count: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    stake_amount_sent: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    validator_amount: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pool_state: Option<i32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    last_election_id: Option<u32>,
 }
 
 impl PoolLsCmd {
@@ -385,42 +414,118 @@ fn display_ton_address(addr: Option<&str>) -> ColoredString {
 }
 
 fn print_pools_table(views: &[PoolView]) {
-    println!("\n{} {} ({})\n", "OK".green().bold(), "Pools:".green(), views.len());
+    let snp: Vec<&PoolView> = views.iter().filter(|v| v.kind == "SNP").collect();
+    let core: Vec<&PoolView> = views.iter().filter(|v| v.kind == "Core").collect();
+
+    if !snp.is_empty() {
+        print_snp_table(&snp);
+    }
+    if !core.is_empty() {
+        print_toncore_table(&core);
+    }
+}
+
+fn print_snp_table(views: &[&PoolView]) {
+    println!("\n{} {} ({})\n", "OK".green().bold(), "SNP pools:".green(), views.len());
     println!(
-        "  {:<15} {:<6} {:<14} {:<50} {}",
+        "  {:<15} {:<14} {:<50} {}",
         "Name".cyan().bold(),
-        "Kind".cyan().bold(),
         "Balance".cyan().bold(),
         "Address".cyan().bold(),
-        "Owner / share".cyan().bold(),
+        "Owner".cyan().bold(),
     );
-    println!("  {}", "─".repeat(137).dimmed());
+    println!("  {}", "─".repeat(130).dimmed());
 
     for v in views {
-        match v.kind.as_str() {
-            "SNP" => {
-                let display_addr = display_ton_address(v.address.as_deref());
-                let display_owner = display_ton_address(v.owner.as_deref());
-                let display_balance =
-                    v.balance.map(|b| display_tons(b).white()).unwrap_or_else(|| "-".red());
+        let display_addr = display_ton_address(v.address.as_deref());
+        let display_owner = display_ton_address(v.owner.as_deref());
+        let display_balance =
+            v.balance.map(|b| display_tons(b).white()).unwrap_or_else(|| "-".red());
+        println!("  {:<15} {:<14} {:<50} {}", v.name, display_balance, display_addr, display_owner,);
+    }
+    println!();
+}
 
-                println!(
-                    "  {:<15} {:<6} {:<14} {:<50} {}",
-                    v.name, "SNP", display_balance, display_addr, display_owner,
-                );
-            }
-            "Core" => {
-                let addrs = v.addresses.as_deref().map(|a| a.join(", ")).unwrap_or_default();
-                let share = v.validator_share.map(|s| format!("{s} bp")).unwrap_or_default();
-                println!(
-                    "  {:<15} {:<6} {:<14} {:<50} share={}",
-                    v.name, "Core", "-", addrs, share,
-                );
-            }
-            _ => {}
+fn print_toncore_table(views: &[&PoolView]) {
+    let total_slots: usize = views.iter().filter_map(|v| v.slots.as_ref()).map(|s| s.len()).sum();
+    println!(
+        "\n{} {} ({} pools, {} slots)\n",
+        "OK".green().bold(),
+        "TONCore pools:".green(),
+        views.len(),
+        total_slots,
+    );
+    println!(
+        "  {:<15} {:<5} {:<14} {:<14} {:<10} {:<8} {:<14} {:<14} {}",
+        "Name".cyan().bold(),
+        "Slot".cyan().bold(),
+        "State".cyan().bold(),
+        "Balance".cyan().bold(),
+        "Noms".cyan().bold(),
+        "Share".cyan().bold(),
+        "Min val.stake".cyan().bold(),
+        "Min nom.stake".cyan().bold(),
+        "Address".cyan().bold(),
+    );
+    println!("  {}", "─".repeat(160).dimmed());
+
+    for v in views {
+        let Some(slots) = v.slots.as_ref() else { continue };
+        if slots.is_empty() {
+            // Pool exists in config but no slots configured at all — surface this.
+            println!("  {:<15} {}", v.name, "(no slots configured)".dimmed());
+            continue;
+        }
+        for s in slots {
+            let display_addr = display_ton_address(s.address.as_deref());
+            let display_state = display_state(&s.state);
+            let display_balance =
+                s.balance.map(|b| display_tons(b).white()).unwrap_or_else(|| "-".red());
+            let noms = match (s.nominators_count, s.max_nominators) {
+                (Some(n), Some(m)) => format!("{n}/{m}"),
+                (Some(n), None) => format!("{n}"),
+                _ => "-".to_string(),
+            };
+            // `validator_share` is stored on-chain in basis points (1 bp = 0.01%);
+            // convert to a percentage for display (e.g. 4000 bp → "40.00%").
+            let share = s
+                .validator_share
+                .map(|sh| format!("{:.2}%", sh as f64 / 100.0))
+                .unwrap_or_else(|| "-".to_string());
+            let min_val = s
+                .min_validator_stake
+                .map(|b| display_tons(b).to_string())
+                .unwrap_or_else(|| "-".to_string());
+            let min_nom = s
+                .min_nominator_stake
+                .map(|b| display_tons(b).to_string())
+                .unwrap_or_else(|| "-".to_string());
+            println!(
+                "  {:<15} {:<5} {:<14} {:<14} {:<10} {:<8} {:<14} {:<14} {}",
+                v.name,
+                s.slot,
+                display_state,
+                display_balance,
+                noms,
+                share,
+                min_val,
+                min_nom,
+                display_addr,
+            );
         }
     }
     println!();
+}
+
+fn display_state(state: &str) -> ColoredString {
+    match state {
+        "active" => "active".green(),
+        "uninit" => "uninit".yellow(),
+        "frozen" => "frozen".red(),
+        "not deployed" => "not deployed".yellow(),
+        "error" => "error".red(),
+        other => other.normal(),
+    }
 }
 
 fn normalize_ton_address(addr: &str, flag_name: &str) -> anyhow::Result<String> {
@@ -721,5 +826,110 @@ mod tests {
             normalized,
             "0:c5770dc489bef32419959c174b787ab95ff9109e0e43239c18059509819697fb"
         );
+    }
+
+    // ---- PoolView serde / table rendering ----
+
+    fn snp_view() -> PoolView {
+        PoolView {
+            name: "snp1".into(),
+            kind: "SNP".into(),
+            balance: Some(123_000_000_000),
+            address: Some(
+                "0:c5770dc489bef32419959c174b787ab95ff9109e0e43239c18059509819697fb".into(),
+            ),
+            owner: Some(
+                "0:c5770dc489bef32419959c174b787ab95ff9109e0e43239c18059509819697fb".into(),
+            ),
+            slots: None,
+        }
+    }
+
+    fn core_view_two_slots() -> PoolView {
+        PoolView {
+            name: "core1".into(),
+            kind: "Core".into(),
+            balance: None,
+            address: None,
+            owner: None,
+            slots: Some(vec![
+                TonCorePoolSlotView {
+                    slot: "even".into(),
+                    address: Some(
+                        "-1:0000000000000000000000000000000000000000000000000000000000000001"
+                            .into(),
+                    ),
+                    state: "active".into(),
+                    balance: Some(50_000_000_000),
+                    validator_share: Some(4000),
+                    max_nominators: Some(40),
+                    min_validator_stake: Some(10_000_000_000_000),
+                    min_nominator_stake: Some(10_000_000_000_000),
+                    nominators_count: Some(3),
+                    stake_amount_sent: Some(0),
+                    validator_amount: Some(0),
+                    pool_state: Some(0),
+                    last_election_id: Some(1_700_000_000),
+                },
+                TonCorePoolSlotView {
+                    slot: "odd".into(),
+                    address: None,
+                    state: "not deployed".into(),
+                    ..Default::default()
+                },
+            ]),
+        }
+    }
+
+    #[test]
+    fn pool_view_snp_json_no_slots_field() {
+        // Round-trip: PoolView → JSON → PoolView. The SNP view must serialize
+        // without a `slots` field so the API contract for SNP stays stable.
+        let view = snp_view();
+        let json = serde_json::to_value(&view).unwrap();
+        assert_eq!(json["kind"], "SNP");
+        assert!(json.get("slots").is_none(), "SNP must not emit slots field");
+        let back: PoolView = serde_json::from_value(json).unwrap();
+        assert_eq!(back.kind, "SNP");
+        assert!(back.slots.is_none());
+    }
+
+    #[test]
+    fn pool_view_toncore_json_round_trip() {
+        let view = core_view_two_slots();
+        let json = serde_json::to_value(&view).unwrap();
+        let slots = json["slots"].as_array().expect("slots present");
+        assert_eq!(slots.len(), 2);
+        assert_eq!(slots[0]["slot"], "even");
+        assert_eq!(slots[0]["validator_share"], 4000);
+        assert_eq!(slots[1]["slot"], "odd");
+        assert_eq!(slots[1]["state"], "not deployed");
+        // Optional fields on the not-deployed slot must be omitted, not null.
+        assert!(slots[1].get("balance").is_none());
+        assert!(slots[1].get("validator_share").is_none());
+
+        let back: PoolView = serde_json::from_value(json).unwrap();
+        let back_slots = back.slots.as_ref().unwrap();
+        assert_eq!(back_slots[0].nominators_count, Some(3));
+        assert_eq!(back_slots[1].state, "not deployed");
+    }
+
+    #[test]
+    fn print_pools_table_handles_mixed_kinds_without_panic() {
+        // Smoke test: rendering must not panic on the new two-table layout
+        // when both an SNP pool and a TONCore pool with mixed slots are
+        // present. Validates the column-formatting code paths for every slot
+        // state we care about.
+        let views = vec![snp_view(), core_view_two_slots()];
+        print_pools_table(&views);
+    }
+
+    #[test]
+    fn print_pools_table_skips_empty_sections() {
+        // Only TONCore configured → SNP renderer must be skipped (no panic,
+        // no "SNP pools (0)" header).
+        print_pools_table(&[core_view_two_slots()]);
+        // Only SNP configured → TONCore renderer is skipped.
+        print_pools_table(&[snp_view()]);
     }
 }

--- a/src/node-control/commands/src/commands/nodectl/config_pool_cmd.rs
+++ b/src/node-control/commands/src/commands/nodectl/config_pool_cmd.rs
@@ -11,16 +11,13 @@ use crate::commands::nodectl::{
     utils::{
         SEND_TIMEOUT, api_delete, api_get, api_post, confirm, get_wallet_config,
         load_config_vault_rpc_client, make_wallet, require_config,
-        resolve_pool_address_from_config, resolve_service_url, save_config,
-        toncore_pool_slot_from_cli_flags, wait_for_seqno_change, wallet_info,
+        resolve_pool_address_from_config, resolve_service_url, toncore_pool_slot_from_cli_flags,
+        wait_for_seqno_change, wallet_info,
     },
 };
 use colored::{ColoredString, Colorize};
 use common::{
-    app_config::{
-        AppConfig, DEFAULT_TONCORE_MAX_NOMINATORS, DEFAULT_TONCORE_MIN_NOMINATOR_STAKE,
-        DEFAULT_TONCORE_MIN_VALIDATOR_STAKE, PoolConfig, TonCoreInitParams, TonCorePoolConfig,
-    },
+    app_config::PoolConfig,
     task_cancellation::CancellationCtx,
     ton_utils::{display_tons, nanotons_to_tons_f64, tons_f64_to_nanotons},
 };
@@ -195,10 +192,10 @@ impl PoolCmd {
         token: Option<&str>,
     ) -> anyhow::Result<()> {
         match &self.action {
-            // SNP add: REST. Core add: local config file (no REST endpoint yet).
+            // Both SNP and Core add go through REST.
             PoolAction::Add(cmd) => match &cmd.action {
                 Some(PoolAddAction::Snp(cmd)) => cmd.run(url, token, config_path).await,
-                Some(PoolAddAction::Core(cmd)) => cmd.run(require_config(config_path)?).await,
+                Some(PoolAddAction::Core(cmd)) => cmd.run(url, token, config_path).await,
                 None => cmd.snp.run(url, token, config_path).await,
             },
             PoolAction::Ls(cmd) => cmd.run(url, token, config_path).await,
@@ -254,60 +251,55 @@ impl PoolAddCmd {
     }
 }
 
+/// Wire body for `POST /v1/pools/core`. Mirrors `service::PoolAddCoreRequest`
+/// — duplicated rather than shared to keep the CLI free of a service-crate
+/// dependency.
+#[derive(serde::Serialize)]
+struct PoolAddCoreBody<'a> {
+    name: &'a str,
+    slot: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    address: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    validator_share: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_nominators: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    min_validator_stake: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    min_nominator_stake: Option<u64>,
+}
+
 impl PoolAddCoreCmd {
-    pub async fn run(&self, path: &Path) -> anyhow::Result<()> {
+    pub async fn run(
+        &self,
+        url: Option<&str>,
+        token: Option<&str>,
+        config_path: Option<&str>,
+    ) -> anyhow::Result<()> {
         if self.address.is_none() && self.validator_share.is_none() {
             anyhow::bail!("At least one of --address or --validator-share must be specified");
         }
 
-        let slot = if self.odd { 1usize } else { 0usize };
-        let slot_name = if slot == 0 { "even" } else { "odd" };
+        let slot_name = if self.odd { "odd" } else { "even" };
 
-        let mut config = AppConfig::load(path)?;
-
+        // Validate locally so the user gets the standard "invalid TON address"
+        // message instead of a 400 from the server.
         let address =
             self.address.as_deref().map(|a| normalize_ton_address(a, "address")).transpose()?;
 
-        let params = self.validator_share.map(|vs| TonCoreInitParams {
-            validator_share: vs,
-            max_nominators: self.max_nominators.unwrap_or(DEFAULT_TONCORE_MAX_NOMINATORS),
-            min_validator_stake: self
-                .min_validator_stake
-                .map(tons_f64_to_nanotons)
-                .unwrap_or(DEFAULT_TONCORE_MIN_VALIDATOR_STAKE),
-            min_nominator_stake: self
-                .min_nominator_stake
-                .map(tons_f64_to_nanotons)
-                .unwrap_or(DEFAULT_TONCORE_MIN_NOMINATOR_STAKE),
-        });
-
-        match config.pools.get_mut(&self.name) {
-            Some(PoolConfig::TONCore { pools }) => {
-                if pools[slot].is_some() {
-                    anyhow::bail!(
-                        "TONCore pool '{}' slot '{}' is already configured. Remove pool first or use another name.",
-                        self.name,
-                        slot_name
-                    );
-                }
-                pools[slot] =
-                    Some(TonCorePoolConfig { address: address.clone(), params: params.clone() });
-            }
-            Some(PoolConfig::SNP { .. }) => {
-                anyhow::bail!(
-                    "Pool '{}' already exists and is SNP. Remove it first or use another name.",
-                    self.name
-                );
-            }
-            None => {
-                let mut pools: [Option<TonCorePoolConfig>; 2] = [None, None];
-                pools[slot] =
-                    Some(TonCorePoolConfig { address: address.clone(), params: params.clone() });
-                config.pools.insert(self.name.clone(), PoolConfig::TONCore { pools });
-            }
-        }
-
-        save_config(&config, path)?;
+        let base_url = resolve_service_url(url, config_path)?;
+        let body = PoolAddCoreBody {
+            name: &self.name,
+            slot: slot_name,
+            address: address.as_deref(),
+            validator_share: self.validator_share,
+            max_nominators: self.max_nominators,
+            // CLI flags accept TON (f64) — convert to nanotons for the API.
+            min_validator_stake: self.min_validator_stake.map(tons_f64_to_nanotons),
+            min_nominator_stake: self.min_nominator_stake.map(tons_f64_to_nanotons),
+        };
+        api_post(&base_url, "/v1/pools/core", token, &body).await?;
 
         let mut info_parts = Vec::new();
         if let Some(vs) = self.validator_share {

--- a/src/node-control/service/src/http/config_handlers.rs
+++ b/src/node-control/service/src/http/config_handlers.rs
@@ -17,9 +17,11 @@ use common::{
     },
     ton_utils::{extract_max_factor, normalize_ton_address},
 };
+use contracts::{NominatorWrapper, TonCoreNominatorWrapper, contract_provider};
 use control_client::client_adnl::ControlClientAdnl;
-use std::{collections::HashMap, path::PathBuf, str::FromStr};
+use std::{collections::HashMap, path::PathBuf, str::FromStr, sync::Arc};
 use ton_block::MsgAddressInt;
+use ton_http_api_client::v2::client_json_rpc::ClientJsonRpc;
 
 /// `type_id` for ADNL public keys (Ed25519).
 const ADNL_PUBKEY_TYPE_ID: i32 = 1209251014;
@@ -68,17 +70,66 @@ pub struct WalletsResponse {
 
 // --- Pools ---
 
+/// Per-slot data for a TONCore nominator pool (one of two physical contracts).
+#[derive(Clone, Default, serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+pub struct TonCorePoolSlotDto {
+    /// Slot identifier: "even" (slot 0) or "odd" (slot 1).
+    pub slot: String,
+    /// Pool contract address (raw form). Absent when neither cache nor
+    /// config has an address for this slot.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address: Option<String>,
+    /// Account state: "active", "uninit", "frozen", "not deployed", or "error".
+    pub state: String,
+    /// On-chain balance in nanotons.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub balance: Option<u64>,
+    /// Validator reward share in basis points.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub validator_share: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_nominators: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_validator_stake: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_nominator_stake: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nominators_count: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stake_amount_sent: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub validator_amount: Option<u64>,
+    /// Pool internal state code (0 = idle, 2 = staking).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pool_state: Option<i32>,
+    /// Last election id the pool staked at (`stake_at` in pool storage).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_election_id: Option<u32>,
+}
+
+/// Pool entry returned by `GET /v1/pools`.
+///
+/// Shape depends on `kind`:
+/// - `"SNP"` — `balance`, `address`, `owner` carry the on-chain data; `slots`
+///   is absent.
+/// - `"Core"` — `slots` carries per-slot on-chain data; `balance`, `address`,
+///   `owner` are always `None` (TONCore pools have two physical contracts, so
+///   there is no single address/balance/owner at the pool level).
 #[derive(Clone, serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 pub struct PoolDto {
     pub name: String,
+    /// `"SNP"` or `"Core"` — selects which of the field groups below applies.
     pub kind: String,
+    /// SNP only: on-chain balance in nanotons. Always `None` for TONCore.
     pub balance: Option<u64>,
+    /// SNP only: pool contract address. Always `None` for TONCore (see `slots`).
     pub address: Option<String>,
+    /// SNP only: owner address from config. Always `None` for TONCore.
     pub owner: Option<String>,
+    /// TONCore only: per-slot data (one entry per configured slot, even/odd).
+    /// Absent for SNP pools.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub addresses: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub validator_share: Option<u64>,
+    pub slots: Option<Vec<TonCorePoolSlotDto>>,
 }
 
 #[derive(Clone, serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
@@ -465,7 +516,7 @@ pub async fn v1_pools_handler(
             .iter()
             .find(|(_, b)| b.pool == Some(name.clone()))
             .map(|(node, _)| node.clone());
-        let (kind, address, balance, owner, addresses, validator_share) = match pool_cfg {
+        let dto = match pool_cfg {
             PoolConfig::SNP { address, owner } => {
                 let (addr, bal) = if let Some(n) = bound_node {
                     // Pool is bound to a node - get the pool instance from the cached pools.
@@ -494,37 +545,132 @@ pub async fn v1_pools_handler(
                 } else {
                     (None, None)
                 };
-                ("SNP".to_string(), addr, bal, owner.clone(), None, None)
+                PoolDto {
+                    name: name.clone(),
+                    kind: "SNP".to_string(),
+                    balance: bal,
+                    address: addr,
+                    owner: owner.clone(),
+                    slots: None,
+                }
             }
             PoolConfig::TONCore { pools } => {
-                let addresses: Vec<String> = pools
-                    .iter()
-                    .map(|slot| {
-                        slot.as_ref()
-                            .and_then(|s| s.address.clone())
-                            .unwrap_or_else(|| "<not deployed>".into())
-                    })
-                    .collect();
-                let validator_share = pools
-                    .iter()
-                    .flatten()
-                    .find_map(|s| s.params.as_ref().map(|p| p.validator_share as u64));
-                ("Core".to_string(), None, None, None, Some(addresses), validator_share)
+                let cached_router = bound_node.as_ref().and_then(|n| cached_pools.get(n).cloned());
+                let cached_inner: Vec<Arc<dyn NominatorWrapper>> =
+                    cached_router.map(|r| r.inner_pools()).unwrap_or_default();
+                let mut cached_iter = cached_inner.into_iter();
+
+                // Build (slot_index, optional config address, optional cached wrapper) for each configured slot.
+                //`inner_pools()` returns wrappers in slot order but skips empty slots,
+                // so we iterate the config and consume the cached iterator only for `Some` entries.
+                let mut slot_jobs = Vec::new();
+                for (idx, slot_cfg) in pools.iter().enumerate() {
+                    let Some(cfg) = slot_cfg.as_ref() else { continue };
+                    let cached = cached_iter.next();
+                    slot_jobs.push((idx, cfg.address.clone(), cached));
+                }
+
+                // Fetch per-slot data in parallel; per-slot RPC errors are encoded into
+                // the slot DTO (state="error") rather than failing the whole response.
+                let mut set = tokio::task::JoinSet::new();
+                for (idx, addr, cached) in slot_jobs {
+                    let rpc_client = rpc_client.clone();
+                    set.spawn(async move {
+                        fetch_toncore_slot_dto(rpc_client, idx, addr, cached).await
+                    });
+                }
+                let mut slots: Vec<TonCorePoolSlotDto> = Vec::new();
+                while let Some(joined) = set.join_next().await {
+                    if let Ok(slot) = joined {
+                        slots.push(slot);
+                    }
+                }
+                slots.sort_by(|a, b| a.slot.cmp(&b.slot));
+
+                PoolDto {
+                    name: name.clone(),
+                    kind: "Core".to_string(),
+                    balance: None,
+                    address: None,
+                    owner: None,
+                    slots: Some(slots),
+                }
             }
         };
-        views.push(PoolDto {
-            name: name.clone(),
-            kind,
-            balance,
-            address,
-            owner,
-            addresses,
-            validator_share,
-        });
+        views.push(dto);
     }
     views.sort_by(|a, b| a.name.cmp(&b.name));
 
     Ok(axum::Json(PoolsResponse { ok: true, result: views }))
+}
+
+/// Fetch on-chain data for a single TONCore pool slot.
+///
+/// Resolution order for the contract address:
+/// 1) the cached wrapper (exists only if pool is bound to a node)
+/// 2) the address from config
+/// 3) no address (treated as not deployed).
+/// When an address is available we hit the RPC for state+balance and
+/// — only when the account is active — call `get_pool_data()` for on-chain
+/// pool parameters.
+/// RPC failures are encoded into the slot DTO so a single
+/// unreachable slot does not break the whole `/v1/pools` response.
+async fn fetch_toncore_slot_dto(
+    rpc_client: Arc<ClientJsonRpc>,
+    slot_idx: usize,
+    config_address: Option<String>,
+    cached: Option<Arc<dyn NominatorWrapper>>,
+) -> TonCorePoolSlotDto {
+    let slot_name = if slot_idx == 0 { "even" } else { "odd" };
+    let address = match &cached {
+        Some(w) => w.address().await.ok(),
+        None => config_address.as_deref().and_then(|a| MsgAddressInt::from_str(a).ok()),
+    };
+    let address_str = address.as_ref().map(|a| a.to_string()).or_else(|| config_address.clone());
+
+    let Some(addr) = address else {
+        return TonCorePoolSlotDto {
+            slot: slot_name.to_string(),
+            address: address_str,
+            state: "not deployed".to_string(),
+            ..Default::default()
+        };
+    };
+
+    let info = rpc_client.get_address_information(&addr).await;
+    let (state_str, balance) = match &info {
+        Ok(info) => (info.state.to_string(), Some(info.balance)),
+        Err(_) => ("error".to_string(), None),
+    };
+
+    let mut dto = TonCorePoolSlotDto {
+        slot: slot_name.to_string(),
+        address: address_str,
+        state: state_str,
+        balance,
+        ..Default::default()
+    };
+
+    // Only query pool data when the contract is active
+    if dto.state == "active" {
+        let wrapper = cached.unwrap_or_else(|| {
+            Arc::new(TonCoreNominatorWrapper::new(contract_provider!(rpc_client.clone()), addr))
+                as Arc<dyn NominatorWrapper>
+        });
+        if let Ok(d) = wrapper.get_pool_data().await {
+            dto.validator_share = Some(d.pool_config.validator_reward_share);
+            dto.max_nominators = Some(d.pool_config.max_nominators_count);
+            dto.min_validator_stake = Some(d.pool_config.min_validator_stake);
+            dto.min_nominator_stake = Some(d.pool_config.nominator_stake_threshold);
+            dto.nominators_count = Some(d.nominators_count);
+            dto.stake_amount_sent = Some(d.stake_amount_sent);
+            dto.validator_amount = Some(d.validator_amount);
+            dto.pool_state = Some(d.state);
+            dto.last_election_id = Some(d.stake_at);
+        }
+    }
+
+    dto
 }
 
 #[utoipa::path(

--- a/src/node-control/service/src/http/config_handlers.rs
+++ b/src/node-control/service/src/http/config_handlers.rs
@@ -123,6 +123,7 @@ pub struct PoolDto {
     /// `"SNP"` or `"Core"` — selects which of the field groups below applies.
     pub kind: String,
     /// SNP only: on-chain balance in nanotons. Always `None` for TONCore.
+    /// For TONCore, see `slots` field instead.
     pub balance: Option<u64>,
     /// SNP only: pool contract address. Always `None` for TONCore (see `slots`).
     pub address: Option<String>,
@@ -659,8 +660,9 @@ async fn fetch_toncore_slot_dto(
     let slot_name = if slot_idx == 0 { "even" } else { "odd" };
     let address = match &cached {
         Some(w) => w.address().await.ok(),
-        None => config_address.as_deref().and_then(|a| MsgAddressInt::from_str(a).ok()),
-    };
+        _ => None,
+    }
+    .or_else(|| config_address.as_deref().and_then(|a| MsgAddressInt::from_str(a).ok()));
     let address_str = address.as_ref().map(|a| a.to_string()).or_else(|| config_address.clone());
 
     let Some(addr) = address else {
@@ -692,16 +694,26 @@ async fn fetch_toncore_slot_dto(
             Arc::new(TonCoreNominatorWrapper::new(contract_provider!(rpc_client.clone()), addr))
                 as Arc<dyn NominatorWrapper>
         });
-        if let Ok(d) = wrapper.get_pool_data().await {
-            dto.validator_share = Some(d.pool_config.validator_reward_share);
-            dto.max_nominators = Some(d.pool_config.max_nominators_count);
-            dto.min_validator_stake = Some(d.pool_config.min_validator_stake);
-            dto.min_nominator_stake = Some(d.pool_config.nominator_stake_threshold);
-            dto.nominators_count = Some(d.nominators_count);
-            dto.stake_amount_sent = Some(d.stake_amount_sent);
-            dto.validator_amount = Some(d.validator_amount);
-            dto.pool_state = Some(d.state);
-            dto.last_election_id = Some(d.stake_at);
+        match wrapper.get_pool_data().await {
+            Ok(d) => {
+                dto.validator_share = Some(d.pool_config.validator_reward_share);
+                dto.max_nominators = Some(d.pool_config.max_nominators_count);
+                dto.min_validator_stake = Some(d.pool_config.min_validator_stake);
+                dto.min_nominator_stake = Some(d.pool_config.nominator_stake_threshold);
+                dto.nominators_count = Some(d.nominators_count);
+                dto.stake_amount_sent = Some(d.stake_amount_sent);
+                dto.validator_amount = Some(d.validator_amount);
+                dto.pool_state = Some(d.state);
+                dto.last_election_id = Some(d.stake_at);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    slot = slot_name,
+                    address = dto.address.as_deref().unwrap_or("-"),
+                    error = %e,
+                    "get_pool_data failed on active account — on-chain fields will be empty",
+                );
+            }
         }
     }
 
@@ -1131,7 +1143,7 @@ pub async fn v1_pools_add_handler(
     path = "/v1/pools/core",
     request_body = PoolAddCoreRequest,
     responses(
-        (status = 200, description = "TONCore pool slot added", body = EntityRefResponse),
+        (status = 201, description = "TONCore pool slot added", body = EntityRefResponse),
         (status = 400, description = "Invalid request", body = ApiErrorResponse),
         (status = 401, description = "Not authenticated", body = ApiErrorResponse),
         (status = 403, description = "Insufficient permissions", body = ApiErrorResponse),
@@ -1184,8 +1196,11 @@ pub async fn v1_pools_add_core_handler(
         }
     }
     if let Some(mn) = req.max_nominators {
-        if mn == 0 {
-            return Err(AppError::bad_request("max_nominators must be > 0"));
+        if !(1..=DEFAULT_TONCORE_MAX_NOMINATORS).contains(&mn) {
+            return Err(AppError::bad_request(format!(
+                "max_nominators must be in 1..={} (got {mn})",
+                DEFAULT_TONCORE_MAX_NOMINATORS
+            )));
         }
     }
 

--- a/src/node-control/service/src/http/config_handlers.rs
+++ b/src/node-control/service/src/http/config_handlers.rs
@@ -12,8 +12,10 @@ use adnl::common::Timeouts;
 use common::{
     TonWalletVersion,
     app_config::{
-        AdnlConfig, BindingStatus, ElectionsConfig, EndpointEntry, KeyConfig, LogConfig, LogOutput,
-        LogRotation, NodeBinding, PoolConfig, StakePolicy, TimeoutVariant, WalletConfig,
+        AdnlConfig, BindingStatus, DEFAULT_TONCORE_MAX_NOMINATORS,
+        DEFAULT_TONCORE_MIN_NOMINATOR_STAKE, DEFAULT_TONCORE_MIN_VALIDATOR_STAKE, ElectionsConfig,
+        EndpointEntry, KeyConfig, LogConfig, LogOutput, LogRotation, NodeBinding, PoolConfig,
+        StakePolicy, TimeoutVariant, TonCoreInitParams, TonCorePoolConfig, WalletConfig,
     },
     ton_utils::{extract_max_factor, normalize_ton_address},
 };
@@ -243,6 +245,7 @@ pub struct WalletAddRequest {
     pub workchain: i32,
 }
 
+/// Request body for `POST /v1/pools` (SNP pools only).
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 pub struct PoolAddRequest {
     pub name: String,
@@ -250,6 +253,38 @@ pub struct PoolAddRequest {
     pub address: Option<String>,
     /// Owner address (raw or base64url). At least one of `address`/`owner` is required.
     pub owner: Option<String>,
+}
+
+/// Request body for `POST /v1/pools/core` — add a TONCore nominator pool slot.
+///
+/// One TONCore pool has up to two slots (even/odd validation rounds). Calling
+/// this with a new `name` creates a fresh TONCore pool with the specified
+/// slot; calling it again with the same `name` and the other `slot` adds
+/// the second slot to the existing pool. Re-adding an already-configured
+/// slot is rejected, as is targeting a name already used by an SNP pool.
+///
+/// At least one of `address` (existing on-chain pool) or `validator_share`
+/// (deploy parameters) must be supplied.
+#[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+pub struct PoolAddCoreRequest {
+    pub name: String,
+    /// Slot identifier: `"even"` (slot 0) or `"odd"` (slot 1).
+    pub slot: String,
+    /// Existing pool contract address (raw or base64url).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address: Option<String>,
+    /// Validator reward share in basis points (1 bp = 0.01%; e.g. 4000 = 40%).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub validator_share: Option<u16>,
+    /// Maximum nominators (default: [`DEFAULT_TONCORE_MAX_NOMINATORS`]).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_nominators: Option<u16>,
+    /// Minimum validator stake in nanotons (default: [`DEFAULT_TONCORE_MIN_VALIDATOR_STAKE`]).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_validator_stake: Option<u64>,
+    /// Minimum nominator stake in nanotons (default: [`DEFAULT_TONCORE_MIN_NOMINATOR_STAKE`]).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_nominator_stake: Option<u64>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
@@ -607,13 +642,13 @@ pub async fn v1_pools_handler(
 /// Fetch on-chain data for a single TONCore pool slot.
 ///
 /// Resolution order for the contract address:
-/// 1) the cached wrapper (exists only if pool is bound to a node)
-/// 2) the address from config
-/// 3) no address (treated as not deployed).
-/// When an address is available we hit the RPC for state+balance and
-/// — only when the account is active — call `get_pool_data()` for on-chain
-/// pool parameters.
-/// RPC failures are encoded into the slot DTO so a single
+///   1. the cached wrapper (exists only if pool is bound to a node);
+///   2. the address from config;
+///   3. no address (treated as not deployed).
+///
+/// When an address is available we hit the RPC for state+balance and — only
+/// when the account is active — call `get_pool_data()` for on-chain pool
+/// parameters. RPC failures are encoded into the slot DTO so a single
 /// unreachable slot does not break the whole `/v1/pools` response.
 async fn fetch_toncore_slot_dto(
     rpc_client: Arc<ClientJsonRpc>,
@@ -1084,6 +1119,135 @@ pub async fn v1_pools_add_handler(
         .runtime_cfg
         .update_and_save(|cfg| {
             cfg.pools.insert(name, pool_config);
+        })
+        .map_err(|e| AppError::internal(e.to_string()))?;
+    state.config_changed.notify_one();
+
+    Ok(axum::Json(EntityRefResponse { ok: true, result: EntityRefDto { name: req.name } }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/pools/core",
+    request_body = PoolAddCoreRequest,
+    responses(
+        (status = 200, description = "TONCore pool slot added", body = EntityRefResponse),
+        (status = 400, description = "Invalid request", body = ApiErrorResponse),
+        (status = 401, description = "Not authenticated", body = ApiErrorResponse),
+        (status = 403, description = "Insufficient permissions", body = ApiErrorResponse),
+        (status = 500, description = "Internal error", body = ApiErrorResponse)
+    ),
+    security(("bearerAuth" = []))
+)]
+pub async fn v1_pools_add_core_handler(
+    state: axum::extract::State<AppState>,
+    req: axum::Json<PoolAddCoreRequest>,
+) -> Result<axum::Json<EntityRefResponse>, AppError> {
+    let req = req.0;
+
+    let slot_idx = match req.slot.as_str() {
+        "even" => 0usize,
+        "odd" => 1usize,
+        other => {
+            return Err(AppError::bad_request(format!(
+                "invalid slot '{other}': must be 'even' or 'odd'"
+            )));
+        }
+    };
+
+    if req.address.is_none() && req.validator_share.is_none() {
+        return Err(AppError::bad_request(
+            "at least one of 'address' or 'validator_share' is required",
+        ));
+    }
+
+    // Sibling deploy-params only take effect when validator_share is also
+    // supplied (without it we never construct TonCoreInitParams).
+    if req.validator_share.is_none()
+        && (req.max_nominators.is_some()
+            || req.min_validator_stake.is_some()
+            || req.min_nominator_stake.is_some())
+    {
+        return Err(AppError::bad_request(
+            "max_nominators / min_validator_stake / min_nominator_stake \
+             require 'validator_share' to be set",
+        ));
+    }
+
+    if let Some(vs) = req.validator_share {
+        // basis points: 1 bp = 0.01%;
+        // >100% is mathematically nonsense.
+        if !(0..=10_000).contains(&vs) {
+            return Err(AppError::bad_request(format!(
+                "validator_share must be in 0..=10000 basis points (got {vs})"
+            )));
+        }
+    }
+    if let Some(mn) = req.max_nominators {
+        if mn == 0 {
+            return Err(AppError::bad_request("max_nominators must be > 0"));
+        }
+    }
+
+    let address = req
+        .address
+        .as_deref()
+        .map(|a| normalize_ton_address(a, "address"))
+        .transpose()
+        .map_err(|e| AppError::bad_request(e.to_string()))?;
+
+    // Build init params only when validator_share is supplied — without it
+    // we can't derive the deployment state, so we treat the slot as
+    // "address-only" (matches the CLI behaviour).
+    let params = req.validator_share.map(|vs| TonCoreInitParams {
+        validator_share: vs,
+        max_nominators: req.max_nominators.unwrap_or(DEFAULT_TONCORE_MAX_NOMINATORS),
+        min_validator_stake: req.min_validator_stake.unwrap_or(DEFAULT_TONCORE_MIN_VALIDATOR_STAKE),
+        min_nominator_stake: req.min_nominator_stake.unwrap_or(DEFAULT_TONCORE_MIN_NOMINATOR_STAKE),
+    });
+
+    // Pre-validate against the live config so we don't half-mutate state on
+    // a failure inside `update_and_save`.
+    {
+        let cfg = state.runtime_cfg.get();
+        match cfg.pools.get(&req.name) {
+            Some(PoolConfig::SNP { .. }) => {
+                return Err(AppError::bad_request(format!(
+                    "pool '{}' already exists and is SNP; remove it first or use another name",
+                    req.name
+                )));
+            }
+            Some(PoolConfig::TONCore { pools }) => {
+                if pools[slot_idx].is_some() {
+                    return Err(AppError::bad_request(format!(
+                        "TONCore pool '{}' slot '{}' is already configured",
+                        req.name, req.slot
+                    )));
+                }
+            }
+            None => {}
+        }
+    }
+
+    let name = req.name.clone();
+    let slot_cfg = TonCorePoolConfig { address, params };
+    state
+        .runtime_cfg
+        .update_and_save(|cfg| {
+            match cfg.pools.get_mut(&name) {
+                Some(PoolConfig::TONCore { pools }) => {
+                    pools[slot_idx] = Some(slot_cfg);
+                }
+                Some(PoolConfig::SNP { .. }) => {
+                    // Pre-validated above; race-narrow window only — leave
+                    // the existing entry untouched.
+                }
+                None => {
+                    let mut pools: [Option<TonCorePoolConfig>; 2] = [None, None];
+                    pools[slot_idx] = Some(slot_cfg);
+                    cfg.pools.insert(name, PoolConfig::TONCore { pools });
+                }
+            }
         })
         .map_err(|e| AppError::internal(e.to_string()))?;
     state.config_changed.notify_one();

--- a/src/node-control/service/src/http/config_handlers_tests.rs
+++ b/src/node-control/service/src/http/config_handlers_tests.rs
@@ -1,0 +1,209 @@
+/*
+ * Copyright (C) 2025-2026 RSquad Blockchain Lab.
+ *
+ * Licensed under the GNU General Public License v3.0.
+ * See the LICENSE file in the root of this repository.
+ *
+ * This software is provided "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ */
+//! Focused unit tests for `v1_pools_handler`, particularly the new TONCore
+//! per-slot output. RPC calls in the test environment fail (no live
+//! ton-http-api endpoint), so tests assert deterministic outcomes for the
+//! "not deployed" path (no address) and the "error" path (RPC unreachable),
+//! plus the SNP shape and slot-ordering invariants.
+use crate::{
+    auth::{jwt::JwtAuth, user_store::UserStore},
+    http::http_server_task::*,
+    runtime_config::{RuntimeConfig, RuntimeConfigStore},
+    task::task_manager::{ServiceTask, TaskController},
+};
+use axum::body::Body;
+use common::{
+    app_config::{AppConfig, HttpConfig, PoolConfig, TonCoreInitParams, TonCorePoolConfig},
+    snapshot::SnapshotStore,
+    task_cancellation::CancellationCtx,
+};
+use http_body_util::BodyExt;
+use std::{collections::HashMap, sync::Arc};
+use tower::ServiceExt;
+
+struct Noop;
+
+#[async_trait::async_trait]
+impl ServiceTask for Noop {
+    async fn run(&self, ctx: CancellationCtx, _: Arc<AppConfig>) -> anyhow::Result<()> {
+        let mut c = ctx.subscribe();
+        let _ = c.changed().await;
+        Ok(())
+    }
+}
+
+const TEST_JWT_SECRET: &str = "KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKio="; // [42u8; 32]
+
+fn empty_app_cfg() -> Arc<AppConfig> {
+    Arc::new(AppConfig {
+        nodes: HashMap::new(),
+        wallets: HashMap::new(),
+        pools: HashMap::new(),
+        bindings: HashMap::new(),
+        ton_http_api: Default::default(),
+        // Auth disabled — tests target the handler logic directly, not the
+        // auth middleware.
+        http: HttpConfig { auth: None, ..Default::default() },
+        elections: Some(Default::default()),
+        voting: None,
+        master_wallet: None,
+        tick_interval: 30,
+        log: Some(Default::default()),
+    })
+}
+
+async fn state_with_pools(pools: HashMap<String, PoolConfig>) -> AppState {
+    let mut cfg = (*empty_app_cfg()).clone();
+    cfg.pools = pools;
+    let rt = Arc::new(RuntimeConfigStore::from_app_config(Arc::new(cfg)));
+    let jwt_auth = Arc::new(JwtAuth::new(None, Some(TEST_JWT_SECRET)).await.unwrap());
+    AppState {
+        store: Arc::new(SnapshotStore::new()),
+        runtime_cfg: rt.clone(),
+        elections_task: Arc::new(TaskController::new("elections", Noop, rt.clone())),
+        jwt_auth,
+        user_store: Arc::new(UserStore::new(rt as Arc<dyn RuntimeConfig>)),
+        login_rate_limiter: Arc::new(tokio::sync::Mutex::new(Default::default())),
+        config_changed: Arc::new(tokio::sync::Notify::new()),
+    }
+}
+
+async fn json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+fn get(uri: &str) -> axum::http::Request<Body> {
+    axum::http::Request::builder().uri(uri).body(Body::empty()).unwrap()
+}
+
+#[tokio::test]
+async fn pools_empty() {
+    let st = state_with_pools(HashMap::new()).await;
+    let resp = routes(false, st).oneshot(get("/v1/pools")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let v = json(resp).await;
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["result"], serde_json::json!([]));
+}
+
+#[tokio::test]
+async fn pools_snp_shape_preserved() {
+    let mut pools = HashMap::new();
+    pools.insert(
+        "snp1".to_string(),
+        PoolConfig::SNP {
+            address: Some(
+                "-1:bd313e9e1114bbbe7af6f28ef59be0ff3f02ac795423f10397a70dc16396c4ea".into(),
+            ),
+            owner: Some(
+                "0:c5770dc489bef32419959c174b787ab95ff9109e0e43239c18059509819697fb".into(),
+            ),
+        },
+    );
+
+    let st = state_with_pools(pools).await;
+    let resp = routes(false, st).oneshot(get("/v1/pools")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let v = json(resp).await;
+    let result = &v["result"][0];
+    assert_eq!(result["name"], "snp1");
+    assert_eq!(result["kind"], "SNP");
+    assert_eq!(
+        result["owner"],
+        "0:c5770dc489bef32419959c174b787ab95ff9109e0e43239c18059509819697fb"
+    );
+    // SNP must not produce a slots field.
+    assert!(result.get("slots").is_none());
+}
+
+#[tokio::test]
+async fn pools_toncore_slot_with_no_address_is_not_deployed() {
+    // Slot configured with params but no address and no binding → pool isn't
+    // on-chain yet. Handler should emit a "not deployed" slot entry rather
+    // than failing or guessing an address.
+    let mut pools = HashMap::new();
+    pools.insert(
+        "core1".to_string(),
+        PoolConfig::TONCore {
+            pools: [
+                Some(TonCorePoolConfig {
+                    address: None,
+                    params: Some(TonCoreInitParams {
+                        validator_share: 4000,
+                        max_nominators: 40,
+                        min_validator_stake: 10_000_000_000_000,
+                        min_nominator_stake: 10_000_000_000_000,
+                    }),
+                }),
+                None,
+            ],
+        },
+    );
+
+    let st = state_with_pools(pools).await;
+    let resp = routes(false, st).oneshot(get("/v1/pools")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let v = json(resp).await;
+    let result = &v["result"][0];
+    assert_eq!(result["kind"], "Core");
+    let slots = result["slots"].as_array().unwrap();
+    // Only the configured (even) slot is reported; the unconfigured odd slot
+    // is omitted entirely.
+    assert_eq!(slots.len(), 1);
+    assert_eq!(slots[0]["slot"], "even");
+    assert_eq!(slots[0]["state"], "not deployed");
+    assert!(slots[0].get("address").is_none());
+    assert!(slots[0].get("balance").is_none());
+    assert!(slots[0].get("validator_share").is_none());
+}
+
+#[tokio::test]
+async fn pools_toncore_both_slots_with_addresses_rpc_unreachable() {
+    // Both slots have addresses but no live RPC — handler must gracefully
+    // produce two slot entries with state="error" instead of returning 500.
+    let mut pools = HashMap::new();
+    pools.insert(
+        "core2".to_string(),
+        PoolConfig::TONCore {
+            pools: [
+                Some(TonCorePoolConfig {
+                    address: Some(
+                        "-1:0000000000000000000000000000000000000000000000000000000000000001"
+                            .into(),
+                    ),
+                    params: None,
+                }),
+                Some(TonCorePoolConfig {
+                    address: Some(
+                        "-1:0000000000000000000000000000000000000000000000000000000000000002"
+                            .into(),
+                    ),
+                    params: None,
+                }),
+            ],
+        },
+    );
+
+    let st = state_with_pools(pools).await;
+    let resp = routes(false, st).oneshot(get("/v1/pools")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let v = json(resp).await;
+    let result = &v["result"][0];
+    let slots = result["slots"].as_array().unwrap();
+    assert_eq!(slots.len(), 2);
+    assert_eq!(slots[0]["slot"], "even");
+    assert_eq!(slots[1]["slot"], "odd");
+    for slot in slots {
+        // RPC failed → state encoded into DTO, not bubbled up.
+        assert_eq!(slot["state"], "error");
+        assert!(slot.get("balance").is_none());
+        assert!(slot["address"].is_string());
+    }
+}

--- a/src/node-control/service/src/http/config_handlers_tests.rs
+++ b/src/node-control/service/src/http/config_handlers_tests.rs
@@ -83,6 +83,15 @@ fn get(uri: &str) -> axum::http::Request<Body> {
     axum::http::Request::builder().uri(uri).body(Body::empty()).unwrap()
 }
 
+fn post_json(uri: &str, body: &impl serde::Serialize) -> axum::http::Request<Body> {
+    axum::http::Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_string(body).unwrap()))
+        .unwrap()
+}
+
 #[tokio::test]
 async fn pools_empty() {
     let st = state_with_pools(HashMap::new()).await;
@@ -206,4 +215,195 @@ async fn pools_toncore_both_slots_with_addresses_rpc_unreachable() {
         assert!(slot.get("balance").is_none());
         assert!(slot["address"].is_string());
     }
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/pools/core
+// ---------------------------------------------------------------------------
+
+fn core_add_body(name: &str, slot: &str) -> serde_json::Value {
+    serde_json::json!({
+        "name": name,
+        "slot": slot,
+        "validator_share": 4000u16,
+    })
+}
+
+#[tokio::test]
+async fn pools_add_core_creates_new_pool_with_one_slot() {
+    let st = state_with_pools(HashMap::new()).await;
+    let resp = routes(false, st.clone())
+        .oneshot(post_json("/v1/pools/core", &core_add_body("core1", "even")))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let v = json(resp).await;
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["result"]["name"], "core1");
+
+    // Live config now has a TONCore pool with only the even slot populated.
+    let cfg = st.runtime_cfg.get();
+    let pool = cfg.pools.get("core1").expect("pool inserted");
+    match pool {
+        PoolConfig::TONCore { pools } => {
+            assert!(pools[0].is_some(), "even slot must be present");
+            assert!(pools[1].is_none(), "odd slot must remain empty");
+            let params = pools[0].as_ref().unwrap().params.as_ref().unwrap();
+            assert_eq!(params.validator_share, 4000);
+        }
+        _ => panic!("expected TONCore pool"),
+    }
+}
+
+#[tokio::test]
+async fn pools_add_core_adds_second_slot_to_existing_pool() {
+    let mut pools = HashMap::new();
+    pools.insert(
+        "core1".to_string(),
+        PoolConfig::TONCore {
+            pools: [
+                Some(TonCorePoolConfig {
+                    address: None,
+                    params: Some(TonCoreInitParams {
+                        validator_share: 4000,
+                        max_nominators: 40,
+                        min_validator_stake: 10_000_000_000_000,
+                        min_nominator_stake: 10_000_000_000_000,
+                    }),
+                }),
+                None,
+            ],
+        },
+    );
+    let st = state_with_pools(pools).await;
+
+    let resp = routes(false, st.clone())
+        .oneshot(post_json("/v1/pools/core", &core_add_body("core1", "odd")))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let cfg = st.runtime_cfg.get();
+    match cfg.pools.get("core1").unwrap() {
+        PoolConfig::TONCore { pools } => {
+            assert!(pools[0].is_some(), "even slot preserved");
+            assert!(pools[1].is_some(), "odd slot added");
+        }
+        _ => panic!("expected TONCore pool"),
+    }
+}
+
+#[tokio::test]
+async fn pools_add_core_rejects_existing_snp_pool() {
+    let mut pools = HashMap::new();
+    pools.insert("name1".to_string(), PoolConfig::SNP { address: None, owner: None });
+    let st = state_with_pools(pools).await;
+
+    let resp = routes(false, st)
+        .oneshot(post_json("/v1/pools/core", &core_add_body("name1", "even")))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    let v = json(resp).await;
+    assert!(v["error"]["message"].as_str().unwrap().contains("SNP"));
+}
+
+#[tokio::test]
+async fn pools_add_core_rejects_already_configured_slot() {
+    let mut pools = HashMap::new();
+    pools.insert(
+        "core1".to_string(),
+        PoolConfig::TONCore {
+            pools: [Some(TonCorePoolConfig { address: None, params: None }), None],
+        },
+    );
+    let st = state_with_pools(pools).await;
+
+    let resp = routes(false, st)
+        .oneshot(post_json("/v1/pools/core", &core_add_body("core1", "even")))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    let v = json(resp).await;
+    assert!(v["error"]["message"].as_str().unwrap().contains("already configured"));
+}
+
+#[tokio::test]
+async fn pools_add_core_rejects_missing_address_and_share() {
+    let st = state_with_pools(HashMap::new()).await;
+    // Body has neither `address` nor `validator_share` — must 400.
+    let body = serde_json::json!({ "name": "core1", "slot": "even" });
+    let resp = routes(false, st).oneshot(post_json("/v1/pools/core", &body)).await.unwrap();
+    assert_eq!(resp.status(), 400);
+}
+
+#[tokio::test]
+async fn pools_add_core_rejects_invalid_slot() {
+    let st = state_with_pools(HashMap::new()).await;
+    let resp = routes(false, st)
+        .oneshot(post_json("/v1/pools/core", &core_add_body("core1", "middle")))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    let v = json(resp).await;
+    assert!(v["error"]["message"].as_str().unwrap().contains("slot"));
+}
+
+#[tokio::test]
+async fn pools_add_core_rejects_validator_share_above_100_pct() {
+    let st = state_with_pools(HashMap::new()).await;
+    // 10001 bp = 100.01% — must be rejected.
+    let body = serde_json::json!({
+        "name": "core1",
+        "slot": "even",
+        "validator_share": 10_001u16,
+    });
+    let resp = routes(false, st).oneshot(post_json("/v1/pools/core", &body)).await.unwrap();
+    assert_eq!(resp.status(), 400);
+}
+
+#[tokio::test]
+async fn pools_add_core_accepts_validator_share_at_100_pct() {
+    // Boundary check: 10000 bp = exactly 100% — must be accepted.
+    let st = state_with_pools(HashMap::new()).await;
+    let body = serde_json::json!({
+        "name": "core1",
+        "slot": "even",
+        "validator_share": 10_000u16,
+    });
+    let resp = routes(false, st).oneshot(post_json("/v1/pools/core", &body)).await.unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+#[tokio::test]
+async fn pools_add_core_rejects_sibling_params_without_validator_share() {
+    // Supplying max_nominators / min_*_stake without validator_share would
+    // silently discard them (no TonCoreInitParams gets built). Must 400 so
+    // the user knows their input was ignored.
+    let st = state_with_pools(HashMap::new()).await;
+    let body = serde_json::json!({
+        "name": "core1",
+        "slot": "even",
+        "address": "-1:0000000000000000000000000000000000000000000000000000000000000001",
+        "max_nominators": 50u16,
+    });
+    let resp = routes(false, st).oneshot(post_json("/v1/pools/core", &body)).await.unwrap();
+    assert_eq!(resp.status(), 400);
+    let v = json(resp).await;
+    assert!(v["error"]["message"].as_str().unwrap().contains("validator_share"));
+}
+
+#[tokio::test]
+async fn pools_add_core_rejects_max_nominators_zero() {
+    let st = state_with_pools(HashMap::new()).await;
+    let body = serde_json::json!({
+        "name": "core1",
+        "slot": "even",
+        "validator_share": 4000u16,
+        "max_nominators": 0u16,
+    });
+    let resp = routes(false, st).oneshot(post_json("/v1/pools/core", &body)).await.unwrap();
+    assert_eq!(resp.status(), 400);
+    let v = json(resp).await;
+    assert!(v["error"]["message"].as_str().unwrap().contains("max_nominators"));
 }

--- a/src/node-control/service/src/http/http_server_task.rs
+++ b/src/node-control/service/src/http/http_server_task.rs
@@ -188,6 +188,10 @@ pub(crate) fn routes(enable_swagger: bool, state: AppState) -> axum::Router {
         )
         .route("/v1/pools", axum::routing::post(super::config_handlers::v1_pools_add_handler))
         .route(
+            "/v1/pools/core",
+            axum::routing::post(super::config_handlers::v1_pools_add_core_handler),
+        )
+        .route(
             "/v1/pools/{name}",
             axum::routing::delete(super::config_handlers::v1_pools_rm_handler),
         )
@@ -839,6 +843,7 @@ impl utoipa::Modify for BearerAuthAddon {
         super::config_handlers::v1_wallets_rm_handler,
         super::config_handlers::v1_pools_handler,
         super::config_handlers::v1_pools_add_handler,
+        super::config_handlers::v1_pools_add_core_handler,
         super::config_handlers::v1_pools_rm_handler,
         super::config_handlers::v1_bindings_handler,
         super::config_handlers::v1_bindings_add_handler,
@@ -883,6 +888,7 @@ impl utoipa::Modify for BearerAuthAddon {
         super::config_handlers::NodeAddRequest,
         super::config_handlers::WalletAddRequest,
         super::config_handlers::PoolAddRequest,
+        super::config_handlers::PoolAddCoreRequest,
         super::config_handlers::BindingAddRequest,
         super::config_handlers::EntityRefDto,
         super::config_handlers::EntityRefResponse,

--- a/src/node-control/service/src/http/http_server_task.rs
+++ b/src/node-control/service/src/http/http_server_task.rs
@@ -10,8 +10,8 @@ use super::{
     config_handlers::{
         BindingDto, BindingElectionStatusDto, BindingsResponse, ElectionsSettingsDto,
         ElectionsSettingsResponse, LogDto, LogResponse, MasterWalletDto, MasterWalletResponse,
-        NodeDto, NodesResponse, PoolDto, PoolsResponse, WalletDto, WalletsResponse,
-        v1_bindings_handler, v1_elections_settings_handler, v1_log_handler,
+        NodeDto, NodesResponse, PoolDto, PoolsResponse, TonCorePoolSlotDto, WalletDto,
+        WalletsResponse, v1_bindings_handler, v1_elections_settings_handler, v1_log_handler,
         v1_master_wallet_handler, v1_nodes_handler, v1_pools_handler, v1_wallets_handler,
     },
     login_rate_limiter::{LoginRateLimiter, login_limiter_key},
@@ -877,6 +877,7 @@ impl utoipa::Modify for BearerAuthAddon {
         WalletsResponse,
         PoolDto,
         PoolsResponse,
+        TonCorePoolSlotDto,
         BindingDto,
         BindingsResponse,
         super::config_handlers::NodeAddRequest,

--- a/src/node-control/service/src/http/mod.rs
+++ b/src/node-control/service/src/http/mod.rs
@@ -14,3 +14,5 @@ pub use http_server_task::run;
 
 #[cfg(test)]
 mod auth_tests;
+#[cfg(test)]
+mod config_handlers_tests;


### PR DESCRIPTION
`config pool ls` and `GET /v1/pools` now render TONCore pools as a per-slot table with state (active / uninit / not deployed / error), balance, and on-chain pool params (validator share, max nominators, min stakes, nominators count, staked amount, pool state, last election id). Slot fetches run in parallel; per-slot RPC failures are encoded into the slot DTO instead of failing the whole response. SNP shape unchanged.

Also adds `POST /v1/pools/core` so `config pool add core` goes through REST like the rest of v0.4.0 entity CRUD instead of writing the local config file. Validates `validator_share` (0..=10000 bp), `max_nominators > 0`, sibling deploy params require `validator_share`, rejects SNP-name collisions and already-configured slots.

Closes SMA-78