### PR TITLE
Fix TONCore frozen stake accounting and singlehost election_id parsing

### DIFF
--- a/src/node-control/elections/src/runner.rs
+++ b/src/node-control/elections/src/runner.rs
@@ -1056,21 +1056,12 @@ impl ElectionRunner {
         if matches!(&node.stake_policy, StakePolicy::Split50 | StakePolicy::AdaptiveSplit50)
             && node.pool.as_ref().is_some_and(|p| p.pool_kind() == PoolKind::TONCore)
         {
-            // TONCore nominator: stake the full liquid balance of the selected pool.
-            if pool_free_balance < min_stake {
-                anyhow::bail!(
-                    "not enough funds: pool_available={} TON, min_stake={} TON",
-                    pool_free_balance as f64 / 1_000_000_000.0,
-                    min_stake as f64 / 1_000_000_000.0
-                );
-            }
-
             tracing::info!(
-                "node [{}] {}: strategy is ignored for TONCore nominator: stake all available balance",
+                "node [{}] {}: TONCore nominator — use total_balance (frozen + pool + elections_stake)",
                 node.stake_policy.to_string(),
                 node_id
             );
-            return Ok(pool_free_balance);
+            return Ok(total_balance);
         }
 
         match &node.stake_policy {

--- a/src/node-control/elections/src/runner.rs
+++ b/src/node-control/elections/src/runner.rs
@@ -1057,7 +1057,7 @@ impl ElectionRunner {
             && node.pool.as_ref().is_some_and(|p| p.pool_kind() == PoolKind::TONCore)
         {
             tracing::info!(
-                "node [{}] {}: TONCore nominator — use total_balance (frozen + pool + elections_stake)",
+                "node [{}] {}: TONCore nominator - ignore, stake all",
                 node.stake_policy.to_string(),
                 node_id
             );

--- a/src/node-control/elections/src/runner.rs
+++ b/src/node-control/elections/src/runner.rs
@@ -1007,6 +1007,7 @@ impl ElectionRunner {
         let min_stake = configs.elections_info.min_stake;
         tracing::info!("node [{}] calc stake", node_id);
         let fee = ELECTOR_STAKE_FEE + NPOOL_COMPUTE_FEE;
+        let stake_addr = node.stake_addr().await?;
         let mut frozen_stake = 0;
         // Calculate frozen stake from past elections
         for election in ctx.past_elections {
@@ -1014,8 +1015,17 @@ impl ElectionRunner {
             if let Some(entry) = validator_entry {
                 let mut pubkey_array = [0u8; 32];
                 pubkey_array.copy_from_slice(&entry.public_key);
-                frozen_stake +=
-                    election.frozen_map.get(&pubkey_array).map(|frozen| frozen.stake).unwrap_or(0);
+                frozen_stake += election
+                    .frozen_map
+                    .get(&pubkey_array)
+                    .map(|frozen| {
+                        if frozen.wallet_addr.as_slice() == stake_addr.as_slice() {
+                            frozen.stake
+                        } else {
+                            0
+                        }
+                    })
+                    .unwrap_or(0);
             }
         }
 

--- a/src/node-control/elections/src/runner_tests.rs
+++ b/src/node-control/elections/src/runner_tests.rs
@@ -32,9 +32,10 @@ use ton_block::{
 
 const POOL_ADDR: [u8; 32] = [0xBBu8; 32];
 const POOL_ADDR_1: [u8; 32] = [0xCCu8; 32];
+const WALLET_ADDR: [u8; 32] = [0xAAu8; 32];
 
 fn wallet_address() -> MsgAddressInt {
-    MsgAddressInt::standard(-1, [0xAAu8; 32])
+    MsgAddressInt::standard(-1, WALLET_ADDR)
 }
 
 fn pool_address() -> MsgAddressInt {
@@ -1125,7 +1126,7 @@ async fn test_recover_with_past_elections_frozen() {
         frozen_map.insert(
             PUB_KEY,
             FrozenParticipant {
-                wallet_addr: POOL_ADDR,
+                wallet_addr: WALLET_ADDR,
                 weight: 123456789123456789,
                 stake: frozen_stake,
                 banned: false,
@@ -2670,6 +2671,85 @@ async fn test_toncore_nominator_selects_free_pool() {
     // wallet_addr should be pool[1] (the free one), not pool[0]
     assert_eq!(participant.wallet_addr, addr_bytes(&pool_address_1()));
     assert_eq!(participant.stake, expected_stake);
+}
+
+#[tokio::test]
+async fn test_toncore_frozen_stake_ignored_when_wallet_addr_mismatches_stake_target() {
+    let node_id = "node-1";
+    let mut harness = TestHarness::new().with_toncore_nominator_pair();
+    let past_election_id = ELECTION_ID - 3600;
+    let misleading_frozen_stake: u64 = 500_000_000_000_000;
+
+    setup_default_elector(&mut harness.elector_mock, ELECTION_ID, 0);
+    harness.elector_mock.expect_past_elections().returning(move || {
+        let mut frozen_map = HashMap::new();
+        frozen_map.insert(
+            PUB_KEY,
+            FrozenParticipant {
+                wallet_addr: POOL_ADDR,
+                weight: 1,
+                stake: misleading_frozen_stake,
+                banned: false,
+            },
+        );
+        Ok(vec![PastElections {
+            election_id: past_election_id,
+            unfreeze_at: ELECTION_ID + 3600,
+            stake_held: 7200,
+            vset_hash: vec![0u8; 32],
+            frozen_map,
+            total_stake: misleading_frozen_stake,
+            bonuses: 0,
+        }])
+    });
+
+    setup_wallet(&mut harness.wallet_mock);
+    harness.wallet_mock.expect_message().returning(|_dest, _value, _payload| Ok(dummy_cell()));
+
+    let (p0, p1) = harness.toncore_nominator_mocks.as_mut().unwrap();
+    setup_toncore_nominator_slot(p0, pool_address(), 2);
+    setup_toncore_nominator_slot(p1, pool_address_1(), 0);
+
+    let pool1_hex = hex::encode(POOL_ADDR_1);
+    harness.provider_mock.expect_account().returning(move |address| {
+        if address.contains(&pool1_hex) {
+            Ok(fake_account(POOL_BALANCE))
+        } else {
+            Ok(fake_account(WALLET_BALANCE))
+        }
+    });
+
+    setup_default_provider_without_account(&mut harness.provider_mock, WALLET_BALANCE);
+
+    let expected_stake = POOL_BALANCE - TONCORE_STORAGE_RESERVE - EXTRA_STORAGE_FEES;
+
+    let mut runner = harness.build(node_id).await;
+    {
+        let node = runner.nodes.get_mut(node_id).unwrap();
+        let mut keys = HashMap::new();
+        keys.insert(
+            past_election_id,
+            ValidatorEntry {
+                key_id: KEY_ID.to_vec(),
+                public_key: vec![],
+                adnl_addrs: vec![(ADNL_ADDR.to_vec(), past_election_id + 7200)],
+                expired_at: past_election_id + 7200,
+            },
+        );
+        node.validator_config = ValidatorConfig { keys };
+    }
+
+    let result = runner.run().await;
+    assert!(result.is_ok(), "run() failed: {:?}", result.err());
+
+    let node = runner.nodes.get(node_id).unwrap();
+    assert!(node.participant.is_some());
+    let participant = node.participant.as_ref().unwrap();
+    assert_eq!(participant.wallet_addr, addr_bytes(&pool_address_1()));
+    assert_eq!(
+        participant.stake, expected_stake,
+        "frozen entry tied to the other TONCore pool must not inflate calc_stake"
+    );
 }
 
 #[tokio::test]

--- a/src/node-control/elections/src/runner_tests.rs
+++ b/src/node-control/elections/src/runner_tests.rs
@@ -1125,7 +1125,7 @@ async fn test_recover_with_past_elections_frozen() {
         frozen_map.insert(
             PUB_KEY,
             FrozenParticipant {
-                wallet_addr: [0xAAu8; 32],
+                wallet_addr: POOL_ADDR,
                 weight: 123456789123456789,
                 stake: frozen_stake,
                 banned: false,

--- a/src/node/tests/test_run_net_py/run_singlehost_nodectl.py
+++ b/src/node/tests/test_run_net_py/run_singlehost_nodectl.py
@@ -1114,7 +1114,8 @@ class Bootstrap:
 
         for it in range(max_iters):
             data = self._fetch_nodectl_elections()
-            eid_raw = (data or {}).get("election_id")
+            r = (data or {}).get("result")
+            eid_raw = r.get("election_id") if isinstance(r, dict) else None
             eid = int(eid_raw) if eid_raw is not None else None
             status = (data or {}).get("status")
             elector_n = self._participant_count()


### PR DESCRIPTION
Only count frozen stake from past elections when the frozen entry wallet matches the current staking address, so dual-pool TONCore nodes do not double-count the other pool.

Update singlehost nodectl bootstrap to read election_id from nested API result when present. Adjust runner test frozen_map wallet to pool address.
