### PR TITLE
fix(elections): source validator snapshot from current vset

### DIFF
--- a/src/node-control/CHANGELOG.md
+++ b/src/node-control/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **master_wallet duplication / deletion** — reserved the logical name `master_wallet` so it cannot collide with a regular wallet entry.
 - **next elections range in `/v1/elections` response** - fixed calculation of next elections range in `/v1/elections` response.
+- **validator snapshot sourced from elections data instead of current vset** — `adnl`, `pubkey`, `key_id`, `key_election_id`, `key_expires_at`, and `stake` in `/v1/validators` were pulled from the pending election bid rather than the active validator set (p34) and `past_elections` frozen map, showing stale values when a node was validating and bidding for the next round simultaneously.
 
 ## [0.3.0] - 2026-03-24
 

--- a/src/node-control/elections/src/runner.rs
+++ b/src/node-control/elections/src/runner.rs
@@ -1190,17 +1190,12 @@ impl ElectionRunner {
     }
 
     async fn build_validators_snapshot(&mut self) -> ValidatorsSnapshot {
-        let current_election_id =
-            self.snapshot_cache.last_elections.as_ref().map(|snapshot| snapshot.election_id);
-
         let mut node_ids = self.nodes.keys().cloned().collect::<Vec<String>>();
         node_ids.sort();
 
         let mut controlled_nodes = Vec::new();
         for node_id in node_ids {
             let node = self.nodes.get_mut(&node_id).expect("node not found");
-            let current_cycle_key =
-                current_election_id.and_then(|election_id| node.validator_config.find(election_id));
 
             let (validator_entry, is_next_validator) = find_validator_entries(
                 node,
@@ -1220,72 +1215,51 @@ impl ElectionRunner {
             node.is_validator = is_validator;
             node.is_next_validator = is_next_validator;
 
-            let participant = node.participant.as_ref();
             let wallet_addr = node.wallet.address().await.ok().map(|a| a.to_string());
             let pool_addr = node.pool_addr_cache.as_ref().map(|a| a.to_string());
-            let pubkey = validator_entry
+            let pubkey = validator_entry.as_ref().map(|(_, entry, ..)| {
+                base64::Engine::encode(
+                    &base64::engine::general_purpose::STANDARD,
+                    entry.public_key.as_bytes(),
+                )
+            });
+            let adnl = validator_entry
                 .as_ref()
-                .map(|(_, entry)| {
-                    base64::Engine::encode(
-                        &base64::engine::general_purpose::STANDARD,
-                        entry.public_key.as_bytes(),
-                    )
+                .and_then(|(_, entry, ..)| {
+                    entry.adnl_addr.as_ref().map(|x| x.as_slice().as_slice())
                 })
-                .or_else(|| {
-                    participant.map(|p| {
-                        base64::Engine::encode(
-                            &base64::engine::general_purpose::STANDARD,
-                            p.pub_key.as_slice(),
-                        )
-                    })
-                });
-            let adnl = current_cycle_key
-                .as_ref()
-                .and_then(|entry| entry.adnl_addr())
-                .as_deref()
-                .or_else(|| {
-                    validator_entry.as_ref().and_then(|(_, entry)| {
-                        entry.adnl_addr.as_ref().map(|x| x.as_slice().as_slice())
-                    })
-                })
-                .or_else(|| participant.map(|p| p.adnl_addr.as_slice()))
                 .map(|x| base64::Engine::encode(&base64::engine::general_purpose::STANDARD, x));
-            let key_id = current_cycle_key
-                .as_ref()
-                .map(|entry| {
-                    base64::Engine::encode(
-                        &base64::engine::general_purpose::STANDARD,
-                        &entry.key_id,
-                    )
-                })
-                .or_else(|| {
-                    if node.key_id.is_empty() {
-                        None
-                    } else {
-                        Some(base64::Engine::encode(
-                            &base64::engine::general_purpose::STANDARD,
-                            &node.key_id,
-                        ))
-                    }
-                });
+            let key_id = validator_entry.as_ref().map(|(.., matched_entry)| {
+                base64::Engine::encode(
+                    &base64::engine::general_purpose::STANDARD,
+                    &matched_entry.key_id,
+                )
+            });
             let (key_election_id, key_expires_at, key_expires_at_utc, is_key_active) =
-                current_cycle_key
+                validator_entry
                     .as_ref()
-                    .map(|entry| {
-                        let expires = entry.expired_at;
+                    .map(|(_, _, matched_election_id, matched_entry)| {
+                        let expires = matched_entry.expired_at;
                         let now = time_format::now();
                         (
-                            current_election_id,
+                            Some(*matched_election_id),
                             Some(expires),
                             Some(time_format::format_ts(expires)),
                             Some(expires > now),
                         )
                     })
                     .unwrap_or((None, None, None, None));
-            let stake = participant.map(|p| nanotons_to_dec_string(p.stake));
+            let stake = validator_entry.as_ref().and_then(|(_, vd, ..)| {
+                let mut pubkey = [0u8; 32];
+                pubkey.copy_from_slice(vd.public_key.as_slice());
+                self.past_elections
+                    .iter()
+                    .find_map(|pe| pe.frozen_map.get(&pubkey))
+                    .map(|frozen| nanotons_to_dec_string(frozen.stake))
+            });
 
-            let validator_index = validator_entry.as_ref().map(|(idx, _)| *idx);
-            let weight = validator_entry.as_ref().map(|(_, entry)| entry.weight);
+            let validator_index = validator_entry.as_ref().map(|(idx, ..)| *idx);
+            let weight = validator_entry.as_ref().map(|(_, entry, ..)| entry.weight);
 
             // Compute and update binding status
             let is_participating = node.participant.is_some();
@@ -1517,13 +1491,13 @@ async fn find_validator_entries(
     node: &mut Node,
     current_vset: Option<&ValidatorSet>,
     next_vset: Option<&ValidatorSet>,
-) -> anyhow::Result<(Option<(u16, ValidatorDescr)>, bool)> {
+) -> anyhow::Result<(Option<(u16, ValidatorDescr, u64, ValidatorEntry)>, bool)> {
     let config = &node.validator_config;
 
     let mut election_ids = config.keys.keys().cloned().collect::<Vec<_>>();
     election_ids.sort();
 
-    let mut current_entry: Option<(u16, ValidatorDescr)> = None;
+    let mut current_entry: Option<(u16, ValidatorDescr, u64, ValidatorEntry)> = None;
     let mut is_in_next = false;
 
     for election_id in &election_ids[election_ids.len().saturating_sub(3)..] {
@@ -1541,7 +1515,8 @@ async fn find_validator_entries(
             && let Some(idx) =
                 vset.list().iter().position(|item| item.public_key.as_slice() == &key)
         {
-            current_entry = Some((u16::try_from(idx)?, vset.list()[idx].clone()));
+            current_entry =
+                Some((u16::try_from(idx)?, vset.list()[idx].clone(), *election_id, entry.clone()));
         }
 
         if !is_in_next

--- a/src/node-control/elections/src/runner_tests.rs
+++ b/src/node-control/elections/src/runner_tests.rs
@@ -22,8 +22,8 @@ use contracts::{
 use mockall::mock;
 use std::{collections::HashMap, sync::Arc, time::Duration};
 use ton_block::{
-    BuilderData, Cell, Coins, ConfigParam15, Deserializable, MsgAddressInt, Number16, SliceData,
-    ValidatorDescr, ValidatorSet,
+    BuilderData, Cell, Coins, ConfigParam15, Deserializable, MsgAddressInt, Number16, SigPubKey,
+    SliceData, UInt256, ValidatorDescr, ValidatorSet,
     config_params::{ConfigParam16, ConfigParam17},
     read_single_root_boc,
 };
@@ -1849,10 +1849,12 @@ async fn test_publish_snapshot_validators() {
     let node_snapshot = &validators.controlled_nodes[0];
     assert_eq!(node_snapshot.node_id, node_id);
     assert!(node_snapshot.wallet_addr.is_some());
-    assert!(node_snapshot.pubkey.is_some());
-    assert!(node_snapshot.adnl.is_some());
-    assert!(node_snapshot.key_id.is_some());
-    assert!(node_snapshot.stake.is_some());
+    // Node is not in the validator set, so vset-derived fields are None.
+    assert!(node_snapshot.pubkey.is_none());
+    assert!(node_snapshot.adnl.is_none());
+    assert!(node_snapshot.key_id.is_none());
+    assert!(node_snapshot.key_election_id.is_none());
+    assert!(node_snapshot.stake.is_none());
     assert!(!node_snapshot.is_validator, "not in vset");
 }
 
@@ -2879,4 +2881,154 @@ fn next_elections_range_after_window_closed_advances_to_next_next_cycle() {
         range.end - range.start,
         (cfg15.elections_start_before - cfg15.elections_end_before) as u64,
     );
+}
+
+// =====================================================
+// TEST: validator snapshot sources fields from vset
+// =====================================================
+
+const ADNL_VSET: [u8; 32] = [0x05u8; 32];
+const FROZEN_STAKE: u64 = 30_000_000_000_000; // 30 000 TON
+
+/// Build a ValidatorSet containing one validator with the given pubkey and ADNL.
+fn make_vset_with_validator(
+    utime_since: u32,
+    utime_until: u32,
+    pubkey: &[u8; 32],
+    adnl: &[u8; 32],
+) -> ValidatorSet {
+    let vd = ValidatorDescr::with_params(
+        SigPubKey::with_bytes(*pubkey),
+        100,
+        Some(UInt256::from(*adnl)),
+    );
+    ValidatorSet::new(utime_since, utime_until, 1, vec![vd]).expect("validator set")
+}
+
+#[tokio::test]
+async fn test_validator_snapshot_uses_vset_data() {
+    let node_id = "node-1";
+    let mut harness = TestHarness::new();
+
+    // Elector: minimal (no active elections needed for snapshot).
+    setup_elector_no_elections(&mut harness.elector_mock);
+
+    // Provider: return validator_config with an existing key entry for ELECTION_ID.
+    harness.provider_mock.expect_validator_config().returning(|| {
+        let mut keys = HashMap::new();
+        keys.insert(
+            ELECTION_ID,
+            crate::providers::ValidatorEntry {
+                key_id: KEY_ID.to_vec(),
+                public_key: vec![],
+                adnl_addrs: vec![(ADNL_ADDR.to_vec(), ELECTION_ID + 7200)],
+                expired_at: ELECTION_ID + 7200,
+            },
+        );
+        Ok(ValidatorConfig { keys })
+    });
+    harness.provider_mock.expect_export_public_key().returning(|_| Ok(PUB_KEY.to_vec()));
+    harness.provider_mock.expect_election_parameters().returning(|| Ok(default_cfg15()));
+    harness.provider_mock.expect_get_current_vset().returning(|| Err(anyhow::anyhow!("skip")));
+    harness.provider_mock.expect_get_next_vset().returning(|| Ok(None));
+    harness.provider_mock.expect_shutdown().returning(|| Ok(()));
+
+    setup_wallet(&mut harness.wallet_mock);
+
+    let mut runner = harness.build(node_id).await;
+    runner.refresh_validator_configs().await;
+
+    // Inject a validator set containing our node with a DIFFERENT adnl than the elections one.
+    let vset = make_vset_with_validator(
+        ELECTION_ID as u32,
+        ELECTION_ID as u32 + 3600,
+        &PUB_KEY,
+        &ADNL_VSET,
+    );
+    runner.snapshot_cache.last_validator_set = Some(vset);
+
+    // Inject past_elections with frozen stake for our pubkey.
+    let mut frozen_map = HashMap::new();
+    frozen_map.insert(
+        PUB_KEY,
+        FrozenParticipant {
+            wallet_addr: [0xAA; 32],
+            weight: 100,
+            stake: FROZEN_STAKE,
+            banned: false,
+        },
+    );
+    runner.past_elections = vec![PastElections {
+        election_id: ELECTION_ID,
+        unfreeze_at: ELECTION_ID + 7200,
+        stake_held: 7200,
+        vset_hash: vec![0; 32],
+        frozen_map,
+        total_stake: FROZEN_STAKE,
+        bonuses: 0,
+    }];
+
+    let store = Arc::new(SnapshotStore::new());
+    runner.publish_snapshot(&store).await;
+
+    let snapshot = store.get();
+    let node_snapshot = &snapshot.validators.controlled_nodes[0];
+
+    assert!(node_snapshot.is_validator, "should be in vset");
+    assert_eq!(node_snapshot.validator_index, Some(0));
+
+    // pubkey and adnl come from vset, NOT from elections data.
+    assert_eq!(
+        node_snapshot.pubkey,
+        Some(base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &PUB_KEY)),
+    );
+    assert_eq!(
+        node_snapshot.adnl,
+        Some(base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &ADNL_VSET)),
+        "adnl must come from vset, not elections"
+    );
+
+    // key_id should come from the vset-matched config entry (KEY_ID).
+    assert_eq!(
+        node_snapshot.key_id,
+        Some(base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &KEY_ID)),
+    );
+    assert_eq!(node_snapshot.key_election_id, Some(ELECTION_ID));
+
+    // stake comes from frozen_map, not participant.
+    assert_eq!(
+        node_snapshot.stake,
+        Some(nanotons_to_dec_string(FROZEN_STAKE)),
+        "stake must come from past_elections frozen_map"
+    );
+}
+
+#[tokio::test]
+async fn test_validator_snapshot_none_when_not_in_vset() {
+    let node_id = "node-1";
+    let mut harness = TestHarness::new();
+
+    setup_default_elector(&mut harness.elector_mock, ELECTION_ID, 0);
+    setup_default_provider(&mut harness.provider_mock, WALLET_BALANCE, None);
+    setup_wallet(&mut harness.wallet_mock);
+
+    let mut runner = harness.build(node_id).await;
+    let _ = runner.run().await;
+
+    // No vset injected — node is NOT a validator.
+    let store = Arc::new(SnapshotStore::new());
+    runner.publish_snapshot(&store).await;
+
+    let snapshot = store.get();
+    let node_snapshot = &snapshot.validators.controlled_nodes[0];
+
+    assert!(!node_snapshot.is_validator, "not in vset");
+    assert!(node_snapshot.pubkey.is_none(), "pubkey must be None when not in vset");
+    assert!(node_snapshot.adnl.is_none(), "adnl must be None when not in vset");
+    assert!(node_snapshot.key_id.is_none(), "key_id must be None when not in vset");
+    assert!(
+        node_snapshot.key_election_id.is_none(),
+        "key_election_id must be None when not in vset"
+    );
+    assert!(node_snapshot.stake.is_none(), "stake must be None when not in vset");
 }


### PR DESCRIPTION
## Summary

- **Bug**: `build_validators_snapshot` sourced `adnl`, `pubkey`, `key_id`, `key_election_id`, `key_expires_at`, `is_key_active`, and `stake` from elections/bid data instead of the active validator set — showing stale or incorrect values when a node is validating AND has submitted a new election bid
- **Fix**: All vset-related snapshot fields now come from the current validator set (p34) and `past_elections.frozen_map`. Extended `find_validator_entries` to return the matched `ValidatorEntry` from the node's config. Fields are `None` when the node is not in the validator set.
- **Tests**: Added `test_validator_snapshot_uses_vset_data` and `test_validator_snapshot_none_when_not_in_vset`; updated existing `test_publish_snapshot_validators`

Closes SMA-79