### PR TITLE
feat(docs): update info about toncore pool

### DIFF
--- a/helm/nodectl/README.md
+++ b/helm/nodectl/README.md
@@ -54,7 +54,7 @@ When you add a pool with just the owner address (no explicit contract address), 
 
 ### TONCore nominator pool
 
-nodectl also supports **TONCore** nominator pools: each logical pool name has an **`even`** and an **`odd`** slot (separate contracts). A single slot participates in **one of two consecutive** validation rounds; to cover **every** round with TONCore you normally configure **both** slots. Validators must **`deposit-validator`** funds into each slot up to at least that slot’s **`min-validator-stake`**. Stake policies **Split50 / AdaptiveSplit50** behave differently than on SNP for TONCore — nodectl uses the **full liquid balance** of the **active** slot’s pool for the stake calculation (see [setup.md — TONCore nominator pools](docs/setup.md#toncore-nominator-pools)).
+nodectl also supports **TONCore** nominator pools: each logical pool name has an **`even`** and an **`odd`** slot (separate contracts). A single slot participates in **one of two consecutive** validation rounds; to cover **every** round with TONCore you normally configure **both** slots. Validators must run **`deposit-validator`** so **validator stake** (TON from the **binding’s validator wallet**) is locked in each slot, at least up to that slot’s **`min-validator-stake`**. Stake policies **Split50 / AdaptiveSplit50** behave differently than on SNP for TONCore — nodectl uses the **full liquid balance** of the **active** slot’s pool for the stake calculation (see [setup.md — TONCore nominator pools](docs/setup.md#toncore-nominator-pools)).
 
 ### Auto-deploy
 

--- a/helm/nodectl/README.md
+++ b/helm/nodectl/README.md
@@ -35,14 +35,14 @@ nodectl uses four independent lists connected by bindings:
 |--------|---------|
 | **Nodes** | ADNL connections to validator Control Servers |
 | **Wallets** | Validator wallets for signing transactions |
-| **Pools** | Single Nominator Pool contracts |
+| **Pools** | Single Nominator Pool (SNP) contracts and/or **TONCore** nominator pool pairs (even + odd slots) |
 | **Bindings** | Map each node to a wallet and optionally a pool |
 
 A binding ties everything together: node `node0` uses wallet `wallet0` and pool `pool0`. This decoupled model allows flexible mapping — wallets and pools are reusable, named independently from nodes.
 
 ### Single Nominator Pool (SNP)
 
-nodectl currently supports **only** Single Nominator Pool contracts for staking. The SNP contract address is deterministic:
+For SNP staking, the contract address is deterministic:
 
 ```
 address = hash(snp_code + owner_address + validator_wallet_address)
@@ -51,6 +51,10 @@ address = hash(snp_code + owner_address + validator_wallet_address)
 This means **each node must have its own wallet**. If two nodes share a wallet (= same validator address), their pools get the same address, which breaks election participation. Always create one wallet per node.
 
 When you add a pool with just the owner address (no explicit contract address), nodectl computes the SNP address automatically on startup from the owner and the bound validator wallet.
+
+### TONCore nominator pool
+
+nodectl also supports **TONCore** nominator pools: each logical pool name has an **`even`** and an **`odd`** slot (separate contracts). A single slot participates in **one of two consecutive** validation rounds; to cover **every** round with TONCore you normally configure **both** slots. Validators must **`deposit-validator`** funds into each slot up to at least that slot’s **`min-validator-stake`**. Stake policies **Split50 / AdaptiveSplit50** behave differently than on SNP for TONCore — nodectl uses the **full liquid balance** of the **active** slot’s pool for the stake calculation (see [setup.md — TONCore nominator pools](docs/setup.md#toncore-nominator-pools)).
 
 ### Auto-deploy
 

--- a/helm/nodectl/docs/elections.md
+++ b/helm/nodectl/docs/elections.md
@@ -134,7 +134,7 @@ nodectl config stake-policy --reset --node node0
 
 ## Single Nominator Pool
 
-nodectl supports Single Nominator Pool (SNP) contracts for staking. When a pool is configured for a node (via bindings), transactions are sent to the pool contract instead of directly to the Elector.
+nodectl supports **Single Nominator Pool (SNP)** and **TONCore** nominator pools for staking. When a pool is configured for a node (via bindings), transactions are sent to the pool contract instead of directly to the Elector.
 
 ### Configuration
 
@@ -171,6 +171,10 @@ When you specify only the `owner` (no `address`), nodectl computes the pool addr
 
 Because the SNP address depends on both the owner and the validator wallet address, nodes that share a wallet produce the same pool address. This prevents them from participating in elections independently. **Always use one wallet per node** when using SNP.
 
+## TONCore nominator pool
+
+TONCore uses **even** and **odd** slots (two contracts per logical pool name), validator **`deposit-validator`** stakes, and different stake-policy behaviour than SNP for **Split50 / AdaptiveSplit50** (full liquid balance of the active slot’s pool). See [setup.md — TONCore nominator pools](setup.md#toncore-nominator-pools).
+
 ---
 
 ## Auto-deploy
@@ -181,7 +185,7 @@ The `contracts_task` runs alongside the elections task and automatically deploys
 |------|--------|------|
 | 1 | Deploy master wallet | balance >= 1 TON |
 | 2 | Deploy each validator wallet | 1 TON + 0.1 TON gas per wallet |
-| 3 | Deploy each SNP pool | 1 TON + 0.1 TON gas per pool |
+| 3 | Deploy each configured pool (SNP and TONCore slots) | 1 TON + 0.1 TON gas per pool deployment |
 | 4 | Top up wallets below 5 TON | 10 TON per top-up |
 
 The master wallet key is auto-generated in vault on first start. You only need to fund the master wallet address — deployment is automatic.

--- a/helm/nodectl/docs/elections.md
+++ b/helm/nodectl/docs/elections.md
@@ -173,7 +173,7 @@ Because the SNP address depends on both the owner and the validator wallet addre
 
 ## TONCore nominator pool
 
-TONCore uses **even** and **odd** slots (two contracts per logical pool name), validator **`deposit-validator`** stakes, and different stake-policy behaviour than SNP for **Split50 / AdaptiveSplit50** (full liquid balance of the active slot’s pool). See [setup.md — TONCore nominator pools](setup.md#toncore-nominator-pools).
+TONCore uses **even** and **odd** slots (two contracts per logical pool name). **`deposit-validator`** moves **validator stake** from the **binding’s wallet** into the chosen slot (see [setup.md — TONCore nominator pools](setup.md#toncore-nominator-pools)). Stake policies **Split50 / AdaptiveSplit50** behave differently than on SNP (full liquid balance of the active slot’s pool).
 
 ---
 

--- a/helm/nodectl/docs/setup.md
+++ b/helm/nodectl/docs/setup.md
@@ -183,6 +183,8 @@ nodectl config pool add core -n core0 --odd \
   --min-nominator-stake 10000
 ```
 
+> **Distinct slot addresses:** the **even** and **odd** contracts must get **different** on-chain addresses. That requires the deploy parameters for the two slots to **not be identical** where the address is derived — a common pattern is to change **`min-validator-stake` by one unit** (TON) between slots (here `10000` vs `10001`). You can vary another numeric field instead, as long as the resulting init data differs.
+
 | Flag | Meaning |
 |------|---------|
 | `--even` / `--odd` | Which validation-round slot this contract covers (required; pick exactly one per command). |
@@ -190,9 +192,11 @@ nodectl config pool add core -n core0 --odd \
 | `--min-validator-stake` | Minimum validator stake locked in the pool, **TON** (CLI default if omitted: `10000`). |
 | `--min-nominator-stake` | Minimum stake per nominator, **TON** (CLI default if omitted: `10000`). |
 
-For production-style TONCore deployments it is common to set **minimum stake per nominator** on the order of **10,000 TON** (`--min-nominator-stake 10000`) and size **validator deposits** so each deposit is **not less than** the slot’s **`min-validator-stake`**.
+For production-style TONCore deployments, operators often set **minimum stake per nominator** around **10,000 TON** on the pool (`--min-nominator-stake 10000`). That is **independent** of the **validator stake**: each **`deposit-validator`** must still send at least that slot’s **`min-validator-stake`** into the pool.
 
-**Validator stake (second difference vs an SNP-only setup):** TONCore requires a **validator deposit** inside the pool (`deposit-validator` message). After the binding exists and the validator wallet is funded on-chain, run:
+**Which account pays:** `deposit-validator` debits **the validator wallet from the binding** (`-b` resolves the binding → the configured **wallet**, not the master wallet and not nominator funds in the pool). Fund that wallet on-chain first; it must cover **`-a` plus gas** (nodectl checks balance before sending).
+
+After the binding exists and the validator wallet is funded, run:
 
 ```bash
 nodectl config pool deposit-validator -b node0 -a 10000 --pool-even --yes
@@ -201,8 +205,8 @@ nodectl config pool deposit-validator -b node0 -a 10001 --pool-odd --yes
 
 | Item | Description |
 |------|-------------|
-| `-b` | Binding name (same as the node name in `config bind add -n …`). |
-| `-a` | Amount in **TON**; must be **≥** that slot’s `min-validator-stake` from the pool config. |
+| `-b` | Binding name (same as the node name in `config bind add -n …`). Used to find the **validator wallet** and pool. |
+| `-a` | **Validator stake** in **TON**, sent from the binding’s wallet into the pool slot; must be **≥** that slot’s `min-validator-stake` from the pool config. |
 | `--pool-even` / `--pool-odd` | Which TONCore slot receives the deposit (default if omitted: even). |
 
 > **`deposit-validator` is executed by the CLI with local vault + RPC** (not via the REST API yet). Run it from the pod shell where `CONFIG_PATH` and `VAULT_URL` are set.
@@ -382,7 +386,7 @@ The `contracts_task` automatically:
 
 1. Deploys the master wallet contract
 2. Deploys each validator wallet (sends 1 TON from master)
-3. Deploys each configured pool contract — SNP pools and TONCore even/odd slots (sends 1 TON from master per deployment as implemented by `contracts_task`)
+3. Deploys each configured pool contract — SNP pools and TONCore even/odd slots (sends 1 TON from master per pool deployment)
 
 Look for: `all contracts are ready` — all wallets and pools are deployed.
 

--- a/helm/nodectl/docs/setup.md
+++ b/helm/nodectl/docs/setup.md
@@ -9,6 +9,7 @@ Step-by-step guide for deploying nodectl and configuring it to manage TON valida
 - [Prerequisites](#prerequisites)
 - [Step 1: Deploy the chart](#step-1-deploy-the-chart)
 - [Step 2: Configure](#step-2-configure)
+  - [TONCore nominator pools](#toncore-nominator-pools)
 - [Step 3: Set up keys](#step-3-set-up-keys)
 - [Step 4: Restart the service](#step-4-restart-the-service)
 - [Step 5: Fund and verify](#step-5-fund-and-verify)
@@ -138,9 +139,13 @@ nodectl config wallet add -n wallet2 -s wallet-key-2
 | `-i` | Subwallet ID | `42` |
 | `-w` | Workchain | `-1` |
 
-> **Why one wallet per node?** The SNP contract address is computed from `owner_address + validator_wallet_address`. If two nodes share a wallet, they produce the same pool address and cannot participate in elections independently. See [Key concepts](../README.md#single-nominator-pool-snp).
+> **Why one wallet per node?** The SNP contract address is computed from `owner_address + validator_wallet_address`. If two nodes share a wallet, they produce the same pool address and cannot participate in elections independently. See [Key concepts](../README.md#single-nominator-pool-snp). TONCore pools use a different model — see [TONCore nominator pools](#toncore-nominator-pools).
 
 ### Add pools
+
+nodectl supports **Single Nominator Pool (SNP)** contracts and **TONCore** nominator pool pairs. SNP is covered first; for TONCore, see [TONCore nominator pools](#toncore-nominator-pools).
+
+#### Single Nominator Pool (SNP)
 
 Add Single Nominator Pools with the owner address. The pool contract address is computed automatically on startup:
 
@@ -157,6 +162,52 @@ If the pool contract is already deployed, pass its address instead:
 ```bash
 nodectl config pool add -n pool0 -a "-1:<POOL_CONTRACT_ADDRESS>"
 ```
+
+#### TONCore nominator pools
+
+A **TONCore** configuration is a **pair of slots** — **`even`** and **`odd`** — under one pool name (for example `core0`). Each slot maps to a **different** on-chain pool contract and participates in **different** validation rounds: with a **single** slot you can validate in **one of two consecutive rounds** only. **SNP**, by contrast, uses one pool contract and can participate every round from that pool.
+
+**If you must validate in every round with TONCore**, add **both** slots for the same logical pool name (`--even` and `--odd`). Bind the node once to that pool name; nodectl keeps both addresses for the pair.
+
+Register the two slots (example — adjust shares and minima to your network and economics):
+
+```bash
+nodectl config pool add core -n core0 --even \
+  --validator-share 1000 \
+  --min-validator-stake 10000 \
+  --min-nominator-stake 10000
+
+nodectl config pool add core -n core0 --odd \
+  --validator-share 1000 \
+  --min-validator-stake 10001 \
+  --min-nominator-stake 10000
+```
+
+| Flag | Meaning |
+|------|---------|
+| `--even` / `--odd` | Which validation-round slot this contract covers (required; pick exactly one per command). |
+| `--validator-share` | Validator reward share in **basis points** (e.g. `1000` = 10%). |
+| `--min-validator-stake` | Minimum validator stake locked in the pool, **TON** (CLI default if omitted: `10000`). |
+| `--min-nominator-stake` | Minimum stake per nominator, **TON** (CLI default if omitted: `10000`). |
+
+For production-style TONCore deployments it is common to set **minimum stake per nominator** on the order of **10,000 TON** (`--min-nominator-stake 10000`) and size **validator deposits** so each deposit is **not less than** the slot’s **`min-validator-stake`**.
+
+**Validator stake (second difference vs an SNP-only setup):** TONCore requires a **validator deposit** inside the pool (`deposit-validator` message). After the binding exists and the validator wallet is funded on-chain, run:
+
+```bash
+nodectl config pool deposit-validator -b node0 -a 10000 --pool-even --yes
+nodectl config pool deposit-validator -b node0 -a 10001 --pool-odd --yes
+```
+
+| Item | Description |
+|------|-------------|
+| `-b` | Binding name (same as the node name in `config bind add -n …`). |
+| `-a` | Amount in **TON**; must be **≥** that slot’s `min-validator-stake` from the pool config. |
+| `--pool-even` / `--pool-odd` | Which TONCore slot receives the deposit (default if omitted: even). |
+
+> **`deposit-validator` is executed by the CLI with local vault + RPC** (not via the REST API yet). Run it from the pod shell where `CONFIG_PATH` and `VAULT_URL` are set.
+
+**Stake policy note (Split50 / AdaptiveSplit50):** Those policies are aimed at **SNP**. For **TONCore**, nodectl **does not** apply the “stake half the balance” rule to the pool the same way: for TONCore it **stakes the full free (liquid) balance** of the **active slot’s** pool for the round (still subject to network minimum stake). If you configure Split50 while using TONCore, expect **whole-pool liquid balance** on the active slot to be considered for the stake amount, not “half of the pool” like a classic SNP Split50.
 
 ### Add bindings
 
@@ -331,7 +382,7 @@ The `contracts_task` automatically:
 
 1. Deploys the master wallet contract
 2. Deploys each validator wallet (sends 1 TON from master)
-3. Deploys each SNP pool contract (sends 1 TON from master)
+3. Deploys each configured pool contract — SNP pools and TONCore even/odd slots (sends 1 TON from master per deployment as implemented by `contracts_task`)
 
 Look for: `all contracts are ready` — all wallets and pools are deployed.
 

--- a/helm/nodectl/docs/setup.md
+++ b/helm/nodectl/docs/setup.md
@@ -183,14 +183,14 @@ nodectl config pool add core -n core0 --odd \
   --min-nominator-stake 10000
 ```
 
-> **Distinct slot addresses:** the **even** and **odd** contracts must get **different** on-chain addresses. That requires the deploy parameters for the two slots to **not be identical** where the address is derived — a common pattern is to change **`min-validator-stake` by one unit** (TON) between slots (here `10000` vs `10001`). You can vary another numeric field instead, as long as the resulting init data differs.
+> **Distinct slot addresses:** the **even** and **odd** contracts must get **different** on-chain addresses. The derived address is a function of the validator wallet plus the slot’s **init parameters**; identical params on both slots yield the **same** address. A common pattern is to change **`min-validator-stake` by one unit** (TON) between slots (this example uses **`10000` vs `10001`**). If you omit **`--min-validator-stake`** on both commands, both slots get the service default (**`100_000` TON**) and you still **must** change another field (e.g. **`--validator-share`**) so the two slots differ. You can vary any numeric deploy field as long as the resulting init data differs.
 
 | Flag | Meaning |
 |------|---------|
 | `--even` / `--odd` | Which validation-round slot this contract covers (required; pick exactly one per command). |
 | `--validator-share` | Validator reward share in **basis points** (e.g. `1000` = 10%). |
-| `--min-validator-stake` | Minimum validator stake locked in the pool, **TON** (CLI default if omitted: `10000`). |
-| `--min-nominator-stake` | Minimum stake per nominator, **TON** (CLI default if omitted: `10000`). |
+| `--min-validator-stake` | Minimum validator stake locked in the pool, **TON**. If omitted, the nodectl service applies **`100_000` TON**. |
+| `--min-nominator-stake` | Minimum stake per nominator, **TON**. If omitted, the nodectl service applies **`10_000` TON**. |
 
 For production-style TONCore deployments, operators often set **minimum stake per nominator** around **10,000 TON** on the pool (`--min-nominator-stake 10000`). That is **independent** of the **validator stake**: each **`deposit-validator`** must still send at least that slot’s **`min-validator-stake`** into the pool.
 

--- a/src/node-control/commands/src/commands/nodectl/config_pool_cmd.rs
+++ b/src/node-control/commands/src/commands/nodectl/config_pool_cmd.rs
@@ -98,7 +98,10 @@ pub struct PoolAddCoreCmd {
     #[arg(long = "max-nominators", help = "Max nominators (default: 40)")]
     max_nominators: Option<u16>,
 
-    #[arg(long = "min-validator-stake", help = "Minimum validator stake in TON (default: 10 000)")]
+    #[arg(
+        long = "min-validator-stake",
+        help = "Minimum validator stake in TON (server default when omitted: 100 000)"
+    )]
     min_validator_stake: Option<f64>,
 
     #[arg(long = "min-nominator-stake", help = "Minimum nominator stake in TON (default: 10 000)")]


### PR DESCRIPTION
## Summary
Documents TONCore nominator pools alongside existing SNP guidance in the Helm nodectl docs: round coverage (even/odd slots), configuring both slots, validator deposit-validator, minimum stake hints, and Split50 / AdaptiveSplit50 behaviour vs SNP. Updates the nodectl README pool model so it no longer reads as SNP-only, and aligns elections.md (pool support wording and auto-deploy table) with the new material.

## Changes
- `helm/nodectl/docs/setup.md` — Split “Add pools” into SNP vs TONCore; add TONCore section (even/odd rounds, pool add core examples, flag table, deposit-validator CLI, REST caveat, Split50 note); clarify wallet callout and contracts_task pool deployment wording.
- `helm/nodectl/README.md` — Extend Pools row and SNP section; add TONCore nominator pool subsection with link to setup.md#toncore-nominator-pools.
- `helm/nodectl/docs/elections.md` — State support for SNP and TONCore; add short TONCore pointer + link; adjust auto-deploy step 3 for both pool kinds.

Closes SMA-82