### PR TITLE
feat(elections): support persistent ADNL address across elections

### DIFF
--- a/src/node-control/CHANGELOG.md
+++ b/src/node-control/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `POST /v1/ton-http-api` (with `append` flag for failover endpoints)
   - `POST /v1/log`
   - `GET /v1/elections/settings`, `GET /v1/nodes`, `GET /v1/wallets`, `GET /v1/pools`, `GET /v1/bindings`, `GET /v1/log`, `GET /v1/master-wallet`
+- **Persistent ADNL address across elections** — validators can now keep the same ADNL address across election cycles instead of generating a fresh one each time. New `elections.static_adnls` config map stores pre-generated ADNL key hashes per node (base64). New `POST /v1/elections/static-adnl` endpoint and `nodectl config elections static-adnl --node <name>` CLI command generate the key on the validator node and save it to config. The election runner re-registers the stored address each cycle via `add_validator_adnl_addr`.
 - **Voting CLI (`nodectl vote`)** — `ls`, `inspect`, `add`, `rm` subcommands to view on-chain config proposals and manage the voting task's tracked-proposals list.
 - **Reserved `master_wallet` name** — `config wallet add` rejects the reserved name `master_wallet`, and `config wallet rm master_wallet` fails immediately with a clear error instead of attempting to mutate the master wallet slot.
 

--- a/src/node-control/README.md
+++ b/src/node-control/README.md
@@ -639,6 +639,18 @@ Disable elections participation for one or more bindings.
 nodectl config elections disable node0
 ```
 
+##### `config elections static-adnl`
+
+Generate a persistent ADNL address for a node and save it to the `elections.static_adnls` config. The ADNL key is created on the validator node via its control server. Once set, the election runner reuses this address every cycle instead of generating a fresh one.
+
+| Flag | Short form | Description |
+|------|------------|-------------|
+| `--node <NAME>` | `-n` | Node name (must exist in `nodes`) |
+
+```bash
+nodectl config elections static-adnl --node node0
+```
+
 ---
 
 ### Key Management Commands
@@ -1109,6 +1121,7 @@ Role columns use the following shorthand: **P** = public (no token), **N** = `no
 | POST | `/v1/elections/include` | O | Enable elections for given bindings |
 | GET | `/v1/elections/settings` | N | Elections configuration (policy, overrides, tick, max-factor, per-binding status) |
 | POST | `/v1/elections/settings` | O | Update elections settings (policy, per-node override, tick, max-factor) |
+| POST | `/v1/elections/static-adnl` | O | Generate and assign a persistent ADNL address for a node |
 | GET | `/v1/validators` | N | Validators snapshot for controlled nodes |
 | POST | `/v1/task/elections` | O | Enable / disable / restart the elections background task |
 | GET | `/v1/nodes` | N | List configured nodes with control-server status |
@@ -1336,6 +1349,31 @@ Unified endpoint for updating elections settings. Replaces the pre-0.4 `POST /v1
   }
 }
 ```
+
+---
+
+#### `POST /v1/elections/static-adnl`
+
+Generate a persistent ADNL address on the validator node and save it to the `elections.static_adnls` config map. The election runner will reuse this address every cycle instead of generating a fresh ephemeral one.
+
+**Request:**
+
+```json
+{ "node": "node0" }
+```
+
+**Response:**
+
+```json
+{
+  "ok": true,
+  "result": {
+    "adnl_addr": "<base64>"
+  }
+}
+```
+
+Calling this endpoint again for the same node generates a **new** key and overwrites the previous one.
 
 ---
 

--- a/src/node-control/commands/src/commands/nodectl/config_elections_cmd.rs
+++ b/src/node-control/commands/src/commands/nodectl/config_elections_cmd.rs
@@ -161,6 +161,8 @@ struct BindingElectionView {
     enable: bool,
     status: BindingStatus,
     stake_policy: StakePolicy,
+    #[serde(default)]
+    static_adnl: Option<String>,
 }
 
 fn print_elections_settings_table(view: &ElectionsSettingsView) {
@@ -177,19 +179,42 @@ fn print_elections_settings_table(view: &ElectionsSettingsView) {
     }
 
     if !view.bindings.is_empty() {
+        let has_static_adnl = view.bindings.iter().any(|b| b.static_adnl.is_some());
         println!("\n  {}", "Bindings:".cyan().bold());
-        println!(
-            "    {:<20} {:<12} {:<16} {}",
-            "Node".cyan(),
-            "Enable".cyan(),
-            "Status".cyan(),
-            "Stake Policy".cyan(),
-        );
-        println!("    {}", "─".repeat(70).dimmed());
+        if has_static_adnl {
+            println!(
+                "    {:<20} {:<12} {:<16} {:<20} {}",
+                "Node".cyan(),
+                "Enable".cyan(),
+                "Status".cyan(),
+                "Stake Policy".cyan(),
+                "Static ADNL".cyan(),
+            );
+        } else {
+            println!(
+                "    {:<20} {:<12} {:<16} {}",
+                "Node".cyan(),
+                "Enable".cyan(),
+                "Status".cyan(),
+                "Stake Policy".cyan(),
+            );
+        }
+        println!("    {}", "─".repeat(if has_static_adnl { 100 } else { 70 }).dimmed());
         for b in &view.bindings {
             let enable_str =
                 if b.enable { "yes".green().to_string() } else { "no".red().to_string() };
-            println!("    {:<20} {:<21} {:<16} {}", b.name, enable_str, b.status, b.stake_policy,);
+            if has_static_adnl {
+                let adnl = b.static_adnl.as_deref().unwrap_or("—");
+                println!(
+                    "    {:<20} {:<21} {:<16} {:<20} {}",
+                    b.name, enable_str, b.status, b.stake_policy, adnl,
+                );
+            } else {
+                println!(
+                    "    {:<20} {:<21} {:<16} {}",
+                    b.name, enable_str, b.status, b.stake_policy,
+                );
+            }
         }
     }
     println!();

--- a/src/node-control/commands/src/commands/nodectl/config_elections_cmd.rs
+++ b/src/node-control/commands/src/commands/nodectl/config_elections_cmd.rs
@@ -38,6 +38,8 @@ pub enum ElectionsAction {
     Enable(EnableCmd),
     /// Disable elections for binding(s)
     Disable(DisableCmd),
+    /// Generate and assign a persistent ADNL address for a node
+    StaticAdnl(StaticAdnlCmd),
 }
 
 #[derive(clap::Args, Clone)]
@@ -92,6 +94,12 @@ pub struct DisableCmd {
     nodes: Vec<String>,
 }
 
+#[derive(clap::Args, Clone)]
+pub struct StaticAdnlCmd {
+    #[arg(short = 'n', long = "node", required = true, help = "Node name")]
+    node: String,
+}
+
 impl ElectionsCfgCmd {
     pub async fn run(
         &self,
@@ -106,6 +114,7 @@ impl ElectionsCfgCmd {
             ElectionsAction::MaxFactor(cmd) => cmd.run(url, token, config_path).await,
             ElectionsAction::Enable(cmd) => cmd.run(url, token, config_path).await,
             ElectionsAction::Disable(cmd) => cmd.run(url, token, config_path).await,
+            ElectionsAction::StaticAdnl(cmd) => cmd.run(url, token, config_path).await,
         }
     }
 }
@@ -333,6 +342,33 @@ impl DisableCmd {
         api_post(&base_url, "/v1/elections/exclude", token, &NodeListBody { nodes: &self.nodes })
             .await?;
         println!("{} Elections disabled for: {}", "OK".green().bold(), self.nodes.join(", "));
+        Ok(())
+    }
+}
+
+#[derive(serde::Serialize)]
+struct StaticAdnlBody<'a> {
+    node: &'a str,
+}
+
+impl StaticAdnlCmd {
+    pub async fn run(
+        &self,
+        url: Option<&str>,
+        token: Option<&str>,
+        config_path: Option<&str>,
+    ) -> anyhow::Result<()> {
+        let base_url = resolve_service_url(url, config_path)?;
+        let resp = api_post(
+            &base_url,
+            "/v1/elections/static-adnl",
+            token,
+            &StaticAdnlBody { node: &self.node },
+        )
+        .await?;
+        let parsed: serde_json::Value = serde_json::from_str(&resp)?;
+        let adnl_addr = parsed["result"]["adnl_addr"].as_str().unwrap_or("unknown");
+        println!("{} Static ADNL address for '{}': {}", "OK".green().bold(), self.node, adnl_addr);
         Ok(())
     }
 }

--- a/src/node-control/common/src/app_config.rs
+++ b/src/node-control/common/src/app_config.rs
@@ -538,7 +538,7 @@ pub struct ElectionsConfig {
     /// If min_validators is not reached within this period, proceed without waiting.
     #[serde(default = "default_waiting_pct")]
     pub waiting_period_pct: f64,
-    /// Pre-generated ADNL key hashes, keyed by node name (base64-encoded).
+    /// Pre-generated ADNL addresses, keyed by node name (base64-encoded).
     /// When a node has an entry here, the runner attaches this existing ADNL address
     /// to the validator key each election instead of generating a fresh one.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]

--- a/src/node-control/common/src/app_config.rs
+++ b/src/node-control/common/src/app_config.rs
@@ -538,6 +538,11 @@ pub struct ElectionsConfig {
     /// If min_validators is not reached within this period, proceed without waiting.
     #[serde(default = "default_waiting_pct")]
     pub waiting_period_pct: f64,
+    /// Pre-generated ADNL key hashes, keyed by node name (base64-encoded).
+    /// When a node has an entry here, the runner attaches this existing ADNL address
+    /// to the validator key each election instead of generating a fresh one.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub static_adnls: HashMap<String, String>,
 }
 
 impl ElectionsConfig {
@@ -587,6 +592,7 @@ impl Default for ElectionsConfig {
             tick_interval: default_tick_interval(),
             sleep_period_pct: default_sleep_pct(),
             waiting_period_pct: default_waiting_pct(),
+            static_adnls: HashMap::new(),
         }
     }
 }

--- a/src/node-control/elections/src/providers/default.rs
+++ b/src/node-control/elections/src/providers/default.rs
@@ -152,4 +152,27 @@ impl ElectionsProvider for DefaultElectionsProvider {
             }
         }
     }
+    async fn generate_adnl_addr(&mut self) -> anyhow::Result<Vec<u8>> {
+        let key_id = self.client.generate_key_pair().await?;
+        self.client
+            .add_adnl_address(&AddAdnlAddressRq { key_hash: key_id.clone(), category: 0 })
+            .await
+            .context("add_adnl_address")?;
+        Ok(key_id)
+    }
+    async fn register_adnl_addr(
+        &mut self,
+        adnl_key_id: Vec<u8>,
+        validator_key_id: Vec<u8>,
+        until: u64,
+    ) -> anyhow::Result<()> {
+        self.client
+            .add_validator_adnl_addr(&AddValidatorAdnlAddrRq {
+                perm_key_hash: validator_key_id,
+                key_hash: adnl_key_id,
+                expire_at: until as i32,
+            })
+            .await
+            .context("add_validator_adnl_addr")
+    }
 }

--- a/src/node-control/elections/src/providers/traits.rs
+++ b/src/node-control/elections/src/providers/traits.rs
@@ -104,4 +104,22 @@ pub trait ElectionsProvider: Send + Sync {
         anyhow::bail!("config_param_17 not implemented")
     }
     async fn get_next_vset(&mut self) -> anyhow::Result<Option<ValidatorSet>>;
+
+    /// Generate a new ADNL key on the validator node and register it as an ADNL address.
+    /// Returns the key_id (32-byte hash) which becomes the ADNL address.
+    async fn generate_adnl_addr(&mut self) -> anyhow::Result<Vec<u8>> {
+        anyhow::bail!("generate_adnl_addr not implemented")
+    }
+
+    /// Attach an existing ADNL address to a validator permanent key for the given election cycle.
+    /// The ADNL key must already exist on the node (created by `generate_adnl_addr`).
+    async fn register_adnl_addr(
+        &mut self,
+        adnl_key_id: Vec<u8>,
+        perm_key_id: Vec<u8>,
+        until: u64,
+    ) -> anyhow::Result<()> {
+        let _ = (adnl_key_id, perm_key_id, until);
+        anyhow::bail!("register_adnl_addr not implemented")
+    }
 }

--- a/src/node-control/elections/src/runner.rs
+++ b/src/node-control/elections/src/runner.rs
@@ -109,6 +109,9 @@ struct Node {
     pool_addr_cache: Option<MsgAddressInt>,
     /// Last error observed for this node during the current/previous tick (stringified).
     last_error: Option<String>,
+    /// Pre-generated static ADNL address (32-byte key hash).
+    /// When set, this address is re-registered each election instead of generating a fresh one.
+    static_adnl_addr: Option<Vec<u8>>,
     /// Excluded from elections (enable = false).
     excluded: bool,
     /// Effective stake policy for this node.
@@ -129,6 +132,23 @@ impl Node {
             Some(addr) => addr.address().storage().to_vec(),
             None => self.wallet.address().await?.address().storage().to_vec(),
         })
+    }
+
+    /// Resolve the ADNL address for this election cycle.
+    /// If a static ADNL is configured, re-register it with the validator key.
+    /// Otherwise, generate a fresh ephemeral ADNL address.
+    async fn resolve_adnl_addr(
+        &mut self,
+        perm_key_id: Vec<u8>,
+        until: u64,
+    ) -> anyhow::Result<Vec<u8>> {
+        match &self.static_adnl_addr {
+            Some(key_id) => {
+                self.api.register_adnl_addr(key_id.clone(), perm_key_id, until).await?;
+                Ok(key_id.clone())
+            }
+            None => self.api.new_adnl_addr(perm_key_id, until).await,
+        }
     }
 
     fn reset_participation(&mut self) {
@@ -281,6 +301,13 @@ impl ElectionRunner {
             let excluded = !binding.map(|b| b.enable).unwrap_or(false);
             let binding_status = binding.map(|b| b.status).unwrap_or(BindingStatus::Idle);
             let stake_policy = elections_config.stake_policy(&node_id).clone();
+            let static_adnl = elections_config.static_adnls.get(&node_id).and_then(|b64| {
+                base64::Engine::decode(&base64::engine::general_purpose::STANDARD, b64)
+                    .map_err(|e| {
+                        tracing::error!("node [{}] invalid static_adnl base64: {}", node_id, e);
+                    })
+                    .ok()
+            });
             nodes.insert(
                 node_id,
                 Node {
@@ -288,6 +315,7 @@ impl ElectionRunner {
                     wallet,
                     pool: node_pools,
                     pool_addr_cache: None,
+                    static_adnl_addr: static_adnl,
                     excluded,
                     stake_policy,
                     key_id: vec![],
@@ -738,13 +766,17 @@ impl ElectionRunner {
                     key_expired_at
                 );
                 let adnl_addr = node
-                    .api
-                    .new_adnl_addr(key_id.clone(), key_expired_at)
+                    .resolve_adnl_addr(key_id.clone(), key_expired_at)
                     .await
-                    .map_err(|e| anyhow::anyhow!("new adnl address error: {}", e))?;
+                    .map_err(|e| anyhow::anyhow!("adnl address error: {}", e))?;
                 tracing::info!(
-                    "node [{}] generate new adnl address: {}",
+                    "node [{}] {} adnl address: {}",
                     node_id,
+                    if node.static_adnl_addr.is_some() {
+                        "registered static"
+                    } else {
+                        "generated new"
+                    },
                     base64::Engine::encode(
                         &base64::engine::general_purpose::STANDARD,
                         adnl_addr.as_slice()

--- a/src/node-control/elections/src/runner_tests.rs
+++ b/src/node-control/elections/src/runner_tests.rs
@@ -119,6 +119,13 @@ mock! {
         async fn config_param_16(&mut self) -> anyhow::Result<ton_block::config_params::ConfigParam16>;
         async fn config_param_17(&mut self) -> anyhow::Result<ton_block::config_params::ConfigParam17>;
         async fn get_next_vset(&mut self) -> anyhow::Result<Option<ValidatorSet>>;
+        async fn generate_adnl_addr(&mut self) -> anyhow::Result<Vec<u8>>;
+        async fn register_adnl_addr(
+            &mut self,
+            adnl_key_id: Vec<u8>,
+            perm_key_id: Vec<u8>,
+            until: u64,
+        ) -> anyhow::Result<()>;
     }
 }
 
@@ -372,6 +379,7 @@ impl TestHarness {
                 tick_interval: 10,
                 sleep_period_pct: 0.0,
                 waiting_period_pct: 0.3,
+                static_adnls: HashMap::new(),
             },
             bindings: HashMap::new(),
         }
@@ -1256,6 +1264,7 @@ async fn test_multiple_nodes_one_excluded() {
         tick_interval: 10,
         sleep_period_pct: 0.0,
         waiting_period_pct: 0.3,
+        static_adnls: HashMap::new(),
     };
 
     let mut bindings = HashMap::new();
@@ -1693,6 +1702,7 @@ async fn test_node_without_wallet_skipped() {
         tick_interval: 10,
         sleep_period_pct: 0.0,
         waiting_period_pct: 0.3,
+        static_adnls: HashMap::new(),
     };
 
     let mut bindings = HashMap::new();
@@ -3108,4 +3118,62 @@ async fn test_validator_snapshot_none_when_not_in_vset() {
         "key_election_id must be None when not in vset"
     );
     assert!(node_snapshot.stake.is_none(), "stake must be None when not in vset");
+}
+
+// =====================================================
+// TEST: static ADNL — register_adnl_addr is called
+// =====================================================
+
+#[tokio::test]
+async fn test_static_adnl_uses_register_instead_of_new() {
+    let node_id = "node-1";
+    let static_adnl = [0xAA_u8; 32];
+    let static_adnl_b64 =
+        base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &static_adnl);
+
+    let mut harness = TestHarness::new();
+    harness.elections_config.static_adnls.insert(node_id.to_string(), static_adnl_b64);
+
+    setup_default_elector(&mut harness.elector_mock, ELECTION_ID, 0);
+
+    // Setup provider WITHOUT new_adnl_addr — it must NOT be called.
+    // Instead, register_adnl_addr must be called.
+    harness.provider_mock.expect_election_parameters().returning(|| Ok(default_cfg15()));
+    harness.provider_mock.expect_validator_config().returning(|| Ok(ValidatorConfig::new()));
+    harness.provider_mock.expect_get_current_vset().returning(|| Err(anyhow::anyhow!("no vset")));
+    harness.provider_mock.expect_get_next_vset().returning(|| Ok(None));
+    harness
+        .provider_mock
+        .expect_new_validator_key()
+        .returning(|_since, _until| Ok((KEY_ID.to_vec(), PUB_KEY.to_vec())));
+    harness.provider_mock.expect_export_public_key().returning(|_key_id| Ok(PUB_KEY.to_vec()));
+    harness.provider_mock.expect_sign().returning(|_key, _data| Ok(SIGNATURE.to_vec()));
+    harness.provider_mock.expect_account().returning(move |_addr| Ok(fake_account(WALLET_BALANCE)));
+    harness.provider_mock.expect_send_boc().returning(|_boc| Ok(()));
+    harness.provider_mock.expect_config_param_16().returning(|| Ok(default_cfg16()));
+    harness.provider_mock.expect_config_param_17().returning(|| Ok(default_cfg17()));
+    harness.provider_mock.expect_shutdown().returning(|| Ok(()));
+
+    // register_adnl_addr: expect exactly 1 call with the static ADNL key_id
+    let expected_adnl = static_adnl.to_vec();
+    harness
+        .provider_mock
+        .expect_register_adnl_addr()
+        .withf(move |adnl_key_id, _perm_key_id, _until| adnl_key_id == expected_adnl.as_slice())
+        .times(1)
+        .returning(|_adnl, _perm, _until| Ok(()));
+
+    // new_adnl_addr must NOT be called (no expectation = panics if called)
+
+    setup_wallet(&mut harness.wallet_mock);
+    harness.wallet_mock.expect_message().returning(|_dest, _value, _payload| Ok(dummy_cell()));
+
+    let mut runner = harness.build(node_id).await;
+    let result = runner.run().await;
+    assert!(result.is_ok(), "run() failed: {:?}", result.err());
+
+    let node = runner.nodes.get(node_id).unwrap();
+    assert!(node.participant.is_some(), "participant should be set");
+    let participant = node.participant.as_ref().unwrap();
+    assert_eq!(participant.adnl_addr, static_adnl.to_vec(), "ADNL must be the static one");
 }

--- a/src/node-control/service/src/http/config_handlers.rs
+++ b/src/node-control/service/src/http/config_handlers.rs
@@ -21,6 +21,7 @@ use common::{
 };
 use contracts::{NominatorWrapper, TonCoreNominatorWrapper, contract_provider};
 use control_client::client_adnl::ControlClientAdnl;
+use elections::providers::{DefaultElectionsProvider, ElectionsProvider};
 use std::{collections::HashMap, path::PathBuf, str::FromStr, sync::Arc};
 use ton_block::MsgAddressInt;
 use ton_http_api_client::v2::client_json_rpc::ClientJsonRpc;
@@ -311,6 +312,25 @@ pub struct EntityRefResponse {
 #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 pub struct OkResponse {
     pub ok: bool,
+}
+
+// --- Static ADNL ---
+
+#[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+pub struct StaticAdnlRequest {
+    /// Node name for which to generate and assign a persistent ADNL address.
+    pub node: String,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+pub struct StaticAdnlDto {
+    pub adnl_addr: String,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+pub struct StaticAdnlResponse {
+    pub ok: bool,
+    pub result: StaticAdnlDto,
 }
 
 // --- Elections settings mutation ---
@@ -1674,4 +1694,64 @@ pub async fn v1_log_set_handler(
     let log = config.log.as_ref().cloned().unwrap_or_default();
     let dto = log_config_to_dto(&log);
     Ok(axum::Json(LogResponse { ok: true, result: dto }))
+}
+
+// ---------------------------------------------------------------------------
+// Static ADNL
+// ---------------------------------------------------------------------------
+
+#[utoipa::path(
+    post,
+    path = "/v1/elections/static-adnl",
+    request_body = StaticAdnlRequest,
+    responses(
+        (status = 200, description = "Static ADNL address generated and saved", body = StaticAdnlResponse),
+        (status = 400, description = "Invalid request", body = ApiErrorResponse),
+        (status = 401, description = "Not authenticated", body = ApiErrorResponse),
+        (status = 500, description = "Internal error", body = ApiErrorResponse)
+    ),
+    security(("bearerAuth" = []))
+)]
+pub async fn v1_elections_static_adnl_handler(
+    state: axum::extract::State<AppState>,
+    req: axum::Json<StaticAdnlRequest>,
+) -> Result<axum::Json<StaticAdnlResponse>, AppError> {
+    let node_name = req.0.node;
+
+    let cfg = state.runtime_cfg.get();
+    if cfg.elections.is_none() {
+        return Err(AppError::bad_request("elections are not configured"));
+    }
+    if !cfg.nodes.contains_key(&node_name) {
+        return Err(AppError::bad_request(format!("node '{}' not found", node_name)));
+    }
+    drop(cfg);
+
+    let mut adnl_configs = state.runtime_cfg.node_adnl_configs().await;
+    let adnl_config = adnl_configs
+        .remove(&node_name)
+        .ok_or_else(|| AppError::bad_request(format!("node '{}' ADNL config error", node_name)))?;
+
+    let mut provider = DefaultElectionsProvider::new(adnl_config);
+    let key_id = provider
+        .generate_adnl_addr()
+        .await
+        .map_err(|e| AppError::internal(format!("generate_adnl_addr: {e}")))?;
+    let _ = provider.shutdown().await;
+
+    let adnl_b64 = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &key_id);
+
+    let node = node_name.clone();
+    let b64 = adnl_b64.clone();
+    state
+        .runtime_cfg
+        .update_and_save(|cfg| {
+            let elections = cfg.elections.get_or_insert_with(ElectionsConfig::default);
+            elections.static_adnls.insert(node, b64);
+        })
+        .map_err(|e| AppError::internal(e.to_string()))?;
+    state.config_changed.notify_one();
+
+    tracing::info!("node [{}] static ADNL address set: {}", node_name, adnl_b64);
+    Ok(axum::Json(StaticAdnlResponse { ok: true, result: StaticAdnlDto { adnl_addr: adnl_b64 } }))
 }

--- a/src/node-control/service/src/http/config_handlers.rs
+++ b/src/node-control/service/src/http/config_handlers.rs
@@ -167,6 +167,8 @@ pub struct BindingElectionStatusDto {
     pub enable: bool,
     pub status: BindingStatus,
     pub stake_policy: StakePolicy,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub static_adnl: Option<String>,
 }
 
 #[derive(Clone, serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
@@ -813,6 +815,7 @@ fn build_binding_election_status(
             enable: b.enable,
             status: b.status,
             stake_policy: elections.stake_policy(name).clone(),
+            static_adnl: elections.static_adnls.get(name).cloned(),
         })
         .collect();
     result.sort_by(|a, b| a.name.cmp(&b.name));

--- a/src/node-control/service/src/http/http_server_task.rs
+++ b/src/node-control/service/src/http/http_server_task.rs
@@ -10,9 +10,10 @@ use super::{
     config_handlers::{
         BindingDto, BindingElectionStatusDto, BindingsResponse, ElectionsSettingsDto,
         ElectionsSettingsResponse, LogDto, LogResponse, MasterWalletDto, MasterWalletResponse,
-        NodeDto, NodesResponse, PoolDto, PoolsResponse, TonCorePoolSlotDto, WalletDto,
-        WalletsResponse, v1_bindings_handler, v1_elections_settings_handler, v1_log_handler,
-        v1_master_wallet_handler, v1_nodes_handler, v1_pools_handler, v1_wallets_handler,
+        NodeDto, NodesResponse, PoolDto, PoolsResponse, StaticAdnlDto, StaticAdnlResponse,
+        TonCorePoolSlotDto, WalletDto, WalletsResponse, v1_bindings_handler,
+        v1_elections_settings_handler, v1_log_handler, v1_master_wallet_handler, v1_nodes_handler,
+        v1_pools_handler, v1_wallets_handler,
     },
     login_rate_limiter::{LoginRateLimiter, login_limiter_key},
 };
@@ -174,6 +175,10 @@ pub(crate) fn routes(enable_swagger: bool, state: AppState) -> axum::Router {
         .route(
             "/v1/elections/settings",
             axum::routing::post(super::config_handlers::v1_elections_settings_update_handler),
+        )
+        .route(
+            "/v1/elections/static-adnl",
+            axum::routing::post(super::config_handlers::v1_elections_static_adnl_handler),
         )
         .route("/v1/task/elections", axum::routing::post(v1_task_elections_handler))
         .route("/v1/nodes", axum::routing::post(super::config_handlers::v1_nodes_add_handler))
@@ -834,6 +839,7 @@ impl utoipa::Modify for BearerAuthAddon {
         v1_validators_handler,
         v1_task_elections_handler,
         super::config_handlers::v1_elections_settings_update_handler,
+        super::config_handlers::v1_elections_static_adnl_handler,
         // It won't compile without full names
         super::config_handlers::v1_nodes_handler,
         super::config_handlers::v1_nodes_add_handler,
@@ -893,6 +899,9 @@ impl utoipa::Modify for BearerAuthAddon {
         super::config_handlers::EntityRefDto,
         super::config_handlers::EntityRefResponse,
         super::config_handlers::OkResponse,
+        super::config_handlers::StaticAdnlRequest,
+        StaticAdnlDto,
+        StaticAdnlResponse,
         super::config_handlers::TonHttpApiRequest,
         super::config_handlers::TonHttpApiResult,
         super::config_handlers::TonHttpApiResponse,


### PR DESCRIPTION
## Summary

- Add `elections.static_adnls` config map to store pre-generated ADNL addresses per node (base64)
- Add `generate_adnl_addr()` and `register_adnl_addr()` to `ElectionsProvider` trait
- Runner reuses stored ADNL address via `register_adnl_addr()` instead of generating a new one each cycle
- New `POST /v1/elections/static-adnl` endpoint: generates ADNL key on the validator node and saves it to config
- New CLI command: `nodectl config elections static-adnl --node <name>`