### PR TITLE
fix: create-proposal script

### DIFF
--- a/src/node-control/contracts/src/nominator/wrapper.rs
+++ b/src/node-control/contracts/src/nominator/wrapper.rs
@@ -29,8 +29,8 @@ pub enum PoolKind {
 ///
 /// TONCore nominator with two pools uses [`crate::nominator::TonCoreNominatorRouter`], which
 /// implements this trait. Use [`inner_pools`](NominatorWrapper::inner_pools) to iterate the
-/// physical pool contracts (deploy, RPC). For single pools `inner_pools` returns an empty vec —
-/// the pool itself is the only physical contract.
+/// physical pool contracts (deploy, RPC). SNP returns `[self]`; single TONCore returns an empty
+/// vec (the pool itself is the only physical contract).
 #[async_trait::async_trait]
 pub trait NominatorWrapper: SmartContract + Send + Sync {
     /// Get the owner and validator addresses stored in the contract
@@ -41,12 +41,12 @@ pub trait NominatorWrapper: SmartContract + Send + Sync {
     fn state_init(&self) -> Option<StateInit> {
         None
     }
-    /// Physical sub-pool contracts (TONCore pair only).
+    /// Physical sub-pool contracts for deploy and RPC.
     ///
     /// Returns the two on-chain [`NominatorWrapper`] contracts for a
-    /// [`TonCoreNominatorRouter`](crate::nominator::TonCoreNominatorRouter), or an empty `Vec`
-    /// for every other pool type (SNP, single TONCore). When the result is empty the pool itself
-    /// is the single physical contract.
+    /// [`TonCoreNominatorRouter`](crate::nominator::TonCoreNominatorRouter), `[self]` for
+    /// [`SingleNominatorWrapper`](crate::nominator::SingleNominatorWrapper) (preserves state_init
+    /// for deploy), or an empty `Vec` for a single TONCore pool.
     fn inner_pools(&self) -> Vec<Arc<dyn NominatorWrapper>>;
     /// Minimum nanotons that must remain in the staking account after a stake withdrawal
     /// (contract storage reserve). SNP = [`SNP_STORAGE_RESERVE`]; TONCore = [`TONCORE_STORAGE_RESERVE`].

--- a/src/node-control/contracts/src/nominator/wrapper.rs
+++ b/src/node-control/contracts/src/nominator/wrapper.rs
@@ -44,8 +44,8 @@ pub trait NominatorWrapper: SmartContract + Send + Sync {
     /// Physical sub-pool contracts for deploy and RPC.
     ///
     /// Returns the two on-chain [`NominatorWrapper`] contracts for a
-    /// [`TonCoreNominatorRouter`](crate::nominator::TonCoreNominatorRouter), 
-    /// [`SingleNominatorWrapper`](crate::nominator::SingleNominatorWrapper) returns 
+    /// [`TonCoreNominatorRouter`](crate::nominator::TonCoreNominatorRouter),
+    /// [`SingleNominatorWrapper`](crate::nominator::SingleNominatorWrapper) returns
     /// a single-element vec containing a wrapper for the same pool (preserves state_init
     /// for deploy).
     fn inner_pools(&self) -> Vec<Arc<dyn NominatorWrapper>>;

--- a/src/node-control/contracts/src/nominator/wrapper.rs
+++ b/src/node-control/contracts/src/nominator/wrapper.rs
@@ -44,9 +44,10 @@ pub trait NominatorWrapper: SmartContract + Send + Sync {
     /// Physical sub-pool contracts for deploy and RPC.
     ///
     /// Returns the two on-chain [`NominatorWrapper`] contracts for a
-    /// [`TonCoreNominatorRouter`](crate::nominator::TonCoreNominatorRouter), `[self]` for
-    /// [`SingleNominatorWrapper`](crate::nominator::SingleNominatorWrapper) (preserves state_init
-    /// for deploy), or an empty `Vec` for a single TONCore pool.
+    /// [`TonCoreNominatorRouter`](crate::nominator::TonCoreNominatorRouter), 
+    /// [`SingleNominatorWrapper`](crate::nominator::SingleNominatorWrapper) returns 
+    /// a single-element vec containing a wrapper for the same pool (preserves state_init
+    /// for deploy).
     fn inner_pools(&self) -> Vec<Arc<dyn NominatorWrapper>>;
     /// Minimum nanotons that must remain in the staking account after a stake withdrawal
     /// (contract storage reserve). SNP = [`SNP_STORAGE_RESERVE`]; TONCore = [`TONCORE_STORAGE_RESERVE`].

--- a/src/node/tests/test_load_net/scripts/create-proposal.ts
+++ b/src/node/tests/test_load_net/scripts/create-proposal.ts
@@ -37,16 +37,16 @@ export async function run(provider: NetworkProvider) {
 
     for (const [name, param] of Object.entries(params)) {
         const id = parseInt(name.slice(1));
-        const queryId = (now << 32) | id;
+        const queryId = (BigInt(now) << 32n) | BigInt(id);
         console.log(`param ${id} is ${criticals.has(id) ? 'critical' : 'not critical'}`);
 
-        const params = (criticals.has(id) ? criticalParamsCell : nonCriticalParamsCell).beginParse();
-        params.loadUint(8);
-        params.loadUint(8);
-        params.loadUint(8);
-        params.loadUint(8);
-        params.loadUint(8);
-        const minStoreSec = params.loadUint(32);
+        const slice = (criticals.has(id) ? criticalParamsCell : nonCriticalParamsCell).beginParse();
+        slice.loadUint(8);
+        slice.loadUint(8);
+        slice.loadUint(8);
+        slice.loadUint(8);
+        slice.loadUint(8);
+        const minStoreSec = slice.loadUint(32);
         console.log(`minStoreSec: ${minStoreSec}`);
         const expiresAt = now + parseInt(process.env.EXPIRES_IN_SECS ?? (await ui.input('Expires in seconds:')));
         console.log(`creating proposal for param ${name}...`);

--- a/src/node/tests/test_load_net/scripts/create-proposal.ts
+++ b/src/node/tests/test_load_net/scripts/create-proposal.ts
@@ -32,15 +32,15 @@ export async function run(provider: NetworkProvider) {
     const criticals = cell10.beginParse().loadDictDirect(Dictionary.Keys.Uint(32), Dictionary.Values.Uint(0));
     console.log("get voting params...");
     const param11 = (await getConfig(11)).beginParse();
-    const nonCriticalParams = param11.loadRef().beginParse();
-    const criticalParams = param11.loadRef().beginParse();
+    const nonCriticalParamsCell = param11.loadRef();
+    const criticalParamsCell = param11.loadRef();
 
     for (const [name, param] of Object.entries(params)) {
         const id = parseInt(name.slice(1));
         const queryId = (now << 32) | id;
         console.log(`param ${id} is ${criticals.has(id) ? 'critical' : 'not critical'}`);
 
-        const params = criticals.has(id) ? criticalParams : nonCriticalParams;
+        const params = (criticals.has(id) ? criticalParamsCell : nonCriticalParamsCell).beginParse();
         params.loadUint(8);
         params.loadUint(8);
         params.loadUint(8);
@@ -179,12 +179,16 @@ async function proposalStoragePrice(
     return result.stack.readBigNumber();
 }
 
+function getBaseUrl(): string {
+    const idx = process.argv.findIndex(arg => arg == '--custom');
+    const url = idx !== -1 ? process.argv[idx + 1] : 'http://127.0.0.1:3301';
+    const baseUrl = url.endsWith("jsonRPC") ? url.slice(0, -7) : url;
+    return baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+}
+
 async function getConfig(id: number): Promise<Cell> {
     try {
-        const idx = process.argv.findIndex(arg => arg == '--custom');
-        const url = idx !== -1 ? process.argv[idx + 1] : 'http://127.0.0.1:3301';
-        const baseUrl = url.endsWith("jsonRPC") ? url.slice(0, -7) : url;
-        const normalizedUrl = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+        const normalizedUrl = getBaseUrl();
         console.log(`getting config ${id} from ${normalizedUrl}`);
         const result = await fetch(`${normalizedUrl}getConfigParam?config_id=${id}`, {
             method: 'GET',
@@ -204,7 +208,7 @@ async function getConfig(id: number): Promise<Cell> {
 }
 
 async function getTransactions(address: Address, limit: number, lt: number, hash: string) {
-    const result = await fetch(`http://127.0.0.1:3301/jsonRPC`, {
+    const result = await fetch(`${getBaseUrl()}jsonRPC`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- Extract shared `getBaseUrl()` so `getTransactions` respects `--custom` URL arg (was hardcoded to `127.0.0.1:3301`)
- Fix Slice cursor consumed across loop iterations — store as `Cell`, call `.beginParse()` per iteration
- Fix `inner_pools` docs to match actual behavior: SNP returns `[self]`, single TONCore returns empty vec