### PR TITLE
feat(wallet ls): wallet addresses display as base64 format

### DIFF
--- a/src/node-control/commands/src/commands/nodectl/config_elections_cmd.rs
+++ b/src/node-control/commands/src/commands/nodectl/config_elections_cmd.rs
@@ -180,39 +180,69 @@ fn print_elections_settings_table(view: &ElectionsSettingsView) {
 
     if !view.bindings.is_empty() {
         let has_static_adnl = view.bindings.iter().any(|b| b.static_adnl.is_some());
+        // Column widths: stake policy strings can be long (e.g. adaptive_split50 (50% or 100%)).
+        // Headers/data must pad plain text before coloring — ANSI must not count toward {:<N}.
+        const W_NODE: usize = 20;
+        const W_ENABLE: usize = 12;
+        const W_STATUS: usize = 18;
+        const W_STAKE: usize = 38;
+        const W_ADNL: usize = 24;
+
         println!("\n  {}", "Bindings:".cyan().bold());
+        let rule_len = 4
+            + W_NODE
+            + W_ENABLE
+            + W_STATUS
+            + W_STAKE
+            + if has_static_adnl { W_ADNL } else { 0 };
         if has_static_adnl {
             println!(
-                "    {:<20} {:<12} {:<16} {:<20} {}",
-                "Node".cyan(),
-                "Enable".cyan(),
-                "Status".cyan(),
-                "Stake Policy".cyan(),
-                "Static ADNL".cyan(),
+                "    {}{}{}{}{}",
+                format!("{:<w$}", "Node", w = W_NODE).cyan(),
+                format!("{:<w$}", "Enable", w = W_ENABLE).cyan(),
+                format!("{:<w$}", "Status", w = W_STATUS).cyan(),
+                format!("{:<w$}", "Stake Policy", w = W_STAKE).cyan(),
+                format!("{:<w$}", "Static ADNL", w = W_ADNL).cyan(),
             );
         } else {
             println!(
-                "    {:<20} {:<12} {:<16} {}",
-                "Node".cyan(),
-                "Enable".cyan(),
-                "Status".cyan(),
-                "Stake Policy".cyan(),
+                "    {}{}{}{}",
+                format!("{:<w$}", "Node", w = W_NODE).cyan(),
+                format!("{:<w$}", "Enable", w = W_ENABLE).cyan(),
+                format!("{:<w$}", "Status", w = W_STATUS).cyan(),
+                format!("{:<w$}", "Stake Policy", w = W_STAKE).cyan(),
             );
         }
-        println!("    {}", "─".repeat(if has_static_adnl { 100 } else { 70 }).dimmed());
+        println!("    {}", "─".repeat(rule_len).dimmed());
         for b in &view.bindings {
-            let enable_str =
-                if b.enable { "yes".green().to_string() } else { "no".red().to_string() };
+            let enable_cell = if b.enable {
+                format!("{:<w$}", "yes", w = W_ENABLE).green()
+            } else {
+                format!("{:<w$}", "no", w = W_ENABLE).red()
+            };
+
+            let status_cell = format!("{:<w_st$}", b.status.to_string(), w_st = W_STATUS);
+            let stake_cell = format!("{:<w_sk$}", b.stake_policy.to_string(), w_sk = W_STAKE);
             if has_static_adnl {
                 let adnl = b.static_adnl.as_deref().unwrap_or("—");
+                let adnl_cell = format!("{:<w_ad$}", adnl, w_ad = W_ADNL);
                 println!(
-                    "    {:<20} {:<21} {:<16} {:<20} {}",
-                    b.name, enable_str, b.status, b.stake_policy, adnl,
+                    "    {:<w$}{}{}{}{}",
+                    b.name,
+                    enable_cell,
+                    status_cell,
+                    stake_cell,
+                    adnl_cell,
+                    w = W_NODE,
                 );
             } else {
                 println!(
-                    "    {:<20} {:<21} {:<16} {}",
-                    b.name, enable_str, b.status, b.stake_policy,
+                    "    {:<w$}{}{}{}",
+                    b.name,
+                    enable_cell,
+                    status_cell,
+                    stake_cell,
+                    w = W_NODE,
                 );
             }
         }

--- a/src/node-control/commands/src/commands/nodectl/config_elections_cmd.rs
+++ b/src/node-control/commands/src/commands/nodectl/config_elections_cmd.rs
@@ -190,7 +190,7 @@ fn print_elections_settings_table(view: &ElectionsSettingsView) {
 
         println!("\n  {}", "Bindings:".cyan().bold());
         let rule_len =
-            4 + W_NODE + W_ENABLE + W_STATUS + W_STAKE + if has_static_adnl { W_ADNL } else { 0 };
+            W_NODE + W_ENABLE + W_STATUS + W_STAKE + if has_static_adnl { W_ADNL } else { 0 };
         if has_static_adnl {
             println!(
                 "    {}{}{}{}{}",

--- a/src/node-control/commands/src/commands/nodectl/config_elections_cmd.rs
+++ b/src/node-control/commands/src/commands/nodectl/config_elections_cmd.rs
@@ -189,12 +189,8 @@ fn print_elections_settings_table(view: &ElectionsSettingsView) {
         const W_ADNL: usize = 24;
 
         println!("\n  {}", "Bindings:".cyan().bold());
-        let rule_len = 4
-            + W_NODE
-            + W_ENABLE
-            + W_STATUS
-            + W_STAKE
-            + if has_static_adnl { W_ADNL } else { 0 };
+        let rule_len =
+            4 + W_NODE + W_ENABLE + W_STATUS + W_STAKE + if has_static_adnl { W_ADNL } else { 0 };
         if has_static_adnl {
             println!(
                 "    {}{}{}{}{}",

--- a/src/node-control/commands/src/commands/nodectl/config_wallet_cmd.rs
+++ b/src/node-control/commands/src/commands/nodectl/config_wallet_cmd.rs
@@ -26,8 +26,10 @@ use common::{
 };
 use contracts::{ElectorWrapper, ElectorWrapperImpl, TonWallet, contract_provider, nominator};
 use elections::providers::{DefaultElectionsProvider, ElectionsProvider};
-use std::{io::Write, path::Path};
-use ton_block::{Cell, MsgAddressInt, write_boc};
+use std::{io::Write, path::Path, str::FromStr};
+use ton_block::{
+    ADDR_FORMAT_BOUNCE, ADDR_FORMAT_URL_SAFE, Cell, MsgAddressInt, write_boc,
+};
 use ton_http_api_client::v2::data_models::AccountState;
 
 const WALLET_SEND_GAS: u64 = 1_000_000; // 0.001 TON
@@ -204,6 +206,15 @@ struct WalletView {
     address: Option<String>,
 }
 
+/// Bounceable base64url display for wallet list.
+fn format_wallet_ls_address(addr: &Option<String>) -> Option<String> {
+    let s = addr.as_ref().map(|s| s.trim().to_string()).filter(|s| !s.is_empty())?;
+    MsgAddressInt::from_str(&s)
+        .ok()
+        .and_then(|a| a.to_string_custom(ADDR_FORMAT_BOUNCE | ADDR_FORMAT_URL_SAFE).ok())
+        .or(Some(s))
+}
+
 impl WalletLsCmd {
     pub async fn run(
         &self,
@@ -214,7 +225,10 @@ impl WalletLsCmd {
         let base_url = resolve_service_url(url, config_path)?;
         let body = api_get(&base_url, "/v1/wallets", token).await?;
         let resp: serde_json::Value = serde_json::from_str(&body)?;
-        let views: Vec<WalletView> = serde_json::from_value(resp["result"].clone())?;
+        let mut views: Vec<WalletView> = serde_json::from_value(resp["result"].clone())?;
+        for v in &mut views {
+            v.address = format_wallet_ls_address(&v.address);
+        }
 
         if views.is_empty() {
             match self.format {

--- a/src/node-control/commands/src/commands/nodectl/config_wallet_cmd.rs
+++ b/src/node-control/commands/src/commands/nodectl/config_wallet_cmd.rs
@@ -27,9 +27,7 @@ use common::{
 use contracts::{ElectorWrapper, ElectorWrapperImpl, TonWallet, contract_provider, nominator};
 use elections::providers::{DefaultElectionsProvider, ElectionsProvider};
 use std::{io::Write, path::Path, str::FromStr};
-use ton_block::{
-    ADDR_FORMAT_BOUNCE, ADDR_FORMAT_URL_SAFE, Cell, MsgAddressInt, write_boc,
-};
+use ton_block::{ADDR_FORMAT_BOUNCE, ADDR_FORMAT_URL_SAFE, Cell, MsgAddressInt, write_boc};
 use ton_http_api_client::v2::data_models::AccountState;
 
 const WALLET_SEND_GAS: u64 = 1_000_000; // 0.001 TON


### PR DESCRIPTION
## Summary

After fetching wallets from the API, `config wallet ls` normalizes each
address to bounceable user-friendly base64url (EQ… / Ef…), so table and
JSON output stay consistent regardless of how the service serializes
addresses.

## Changes

- `config_wallet_cmd`: add `format_wallet_ls_address` (same pattern as
  pool list `display_ton_address`: MsgAddressInt parse +
  ADDR_FORMAT_BOUNCE | ADDR_FORMAT_URL_SAFE); apply it when building
  `WalletLs` output.
  
 Closes SMA-84.