### PR TITLE
feat: use highload wallet for adding nominators

### DIFF
--- a/src/node/tests/test_load_net/bun.lock
+++ b/src/node/tests/test_load_net/bun.lock
@@ -14,6 +14,7 @@
         "@ton/sandbox": "^0.36.0",
         "@ton/test-utils": "^0.10.0",
         "@ton/ton": "^15.2.1",
+        "@tonkite/highload-wallet-v3": "3.0.2",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.15.24",
         "bip39": "^3.1.0",
@@ -220,6 +221,8 @@
     "@tonconnect/protocol": ["@tonconnect/protocol@2.2.6", "", { "dependencies": { "tweetnacl": "^1.0.3", "tweetnacl-util": "^0.15.1" } }, "sha512-kyoDz5EqgsycYP+A+JbVsAUYHNT059BCrK+m0pqxykMODwpziuSAXfwAZmHcg8v7NB9VKYbdFY55xKeXOuEd0w=="],
 
     "@tonconnect/sdk": ["@tonconnect/sdk@2.2.0", "", { "dependencies": { "@tonconnect/isomorphic-eventsource": "^0.0.1", "@tonconnect/isomorphic-fetch": "^0.0.2", "@tonconnect/protocol": "^2.2.5" } }, "sha512-8plnAXzaLhapUnt47ZqAOQSIQ8NHSvgTSR74QVJdPWqg8128smgGM4cDYewKdBfTD6Lup0odT1WMMrJu+rE4NQ=="],
+
+    "@tonkite/highload-wallet-v3": ["@tonkite/highload-wallet-v3@3.0.2", "", { "peerDependencies": { "@ton/core": "^0.56.3", "@ton/crypto": "^3.3.0" } }, "sha512-aRCj+ppAzv+dT9PGhlzu8t6rbtoOw9naHVefAOa1jPHG3mLVjOExnNOavYf5fmO0VMFTtcrVPmCAKxhAlkEZtg=="],
 
     "@tonstudio/parser-runtime": ["@tonstudio/parser-runtime@0.0.1", "", {}, "sha512-5s4fLkXWxa4SAd7QGGvJXe13GakEo0J3VF5dUI/i3A//bGZxMwCp1FcnbErpNs3y0LcAZoXE5FCUnDowDQptqw=="],
 

--- a/src/node/tests/test_load_net/package.json
+++ b/src/node/tests/test_load_net/package.json
@@ -23,6 +23,7 @@
         "@ton/sandbox": "^0.36.0",
         "@ton/test-utils": "^0.10.0",
         "@ton/ton": "^15.2.1",
+        "@tonkite/highload-wallet-v3": "3.0.2",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.15.24",
         "bip39": "^3.1.0",

--- a/src/node/tests/test_load_net/scripts/add-nominators-to-pool.ts
+++ b/src/node/tests/test_load_net/scripts/add-nominators-to-pool.ts
@@ -4,9 +4,6 @@
  * Pool FunC (`pool.fc`): nominator deposit uses **`op == 0`**, **`action == 100`** ('d'), value in message.
  * **`throw_unless(61, sender_wc == 0)`** — nominators must use **basechain (workchain 0)** wallets, not masterchain.
  *
- * CI / throughput: deploy+fund uses a **Highload Wallet v3** on masterchain (same key material as `MASTER_WALLET_KEY`)
- * in **one** `sendBatch` external carrying all deploy+fund `internal` messages; stake messages are then sent **in parallel**
- * from each nominator contract (each signs as its own V3R2). Large `count` / HTTP limits may return 500 — then raise gas / reduce N or use master-only path manually.
  *
  * Usage:
  *   bun scripts/add-nominators-to-pool.ts <pool_address> [amount_ton] [count]
@@ -25,8 +22,6 @@
  *   NOMINATOR_FUND_EXTRA_TON (default 0.15)
  *   POOL_INFO_DELAY_MS — wait before get_pool_data dump (default 5000)
  *   TONCORE_POOL_INFO_EXTRA — comma-separated extra pool addresses to print after (same API)
- *
- * Highload: each run starts `HighloadWalletV3.newSequence()`; reusing the same on-chain highload contract must match the next query id (see logged line after `sendBatch`).
  */
 import { TonClient } from "@ton/ton";
 import { Address, beginCell, fromNano, internal, SendMode, toNano } from "@ton/core";
@@ -49,12 +44,8 @@ const DEFAULT_POOL_INFO_DELAY_MS = 5000;
 
 /** Highload wallet timeout (seconds). */
 const HIGHLOAD_TIMEOUT_SEC = 60 * 60 * 24;
-/** After master→highload deploy/topup: poll until active and funded. */
-const HIGHLOAD_DEPLOY_FUND_WAIT_MS = 600_000;
-/** After highload `sendBatch`: wait until nominator wallets answer `seqno`. */
-const NOMINATOR_HL_DEPLOY_WAIT_MS = 600_000;
-/** Final poll until every nominator wallet is active. */
-const NOMINATOR_DEPLOY_WAIT_MS = 600_000;
+/** Max wait for master→highload fund poll and nominator `seqno` readiness (slow RPC / singlehost). */
+const SCRIPT_CHAIN_POLL_MAX_MS = 600_000;
 
 /** pool.fc: `op == 0`, `action == 100` ('d') */
 const TONCORE_ACTION_NOMINATOR_DEPOSIT = 100;
@@ -277,7 +268,7 @@ async function run() {
                 messages: [
                     internal({
                         to: highloadWallet.address,
-                        value: highloadTopup,
+                        value: highloadTopup + toNano("1"), // 1 TON for fees
                         bounce: false,
                         init: hlDeployed ? undefined : highloadWallet.init,
                     }),
@@ -299,7 +290,7 @@ async function run() {
                 const b = await client.getBalance(highloadWallet.address);
                 return b >= highloadFundedMinBalance;
             },
-            HIGHLOAD_DEPLOY_FUND_WAIT_MS,
+            SCRIPT_CHAIN_POLL_MAX_MS,
             2000,
         );
     }
@@ -317,25 +308,16 @@ async function run() {
         throw new Error(e instanceof Error ? e.message : String(e));
     }
     highloadWallet.sequence.next();
-    try {
-        await waitUntilAllWalletsSeqnoReady(client, nominatorWallets, "hl-deploy", NOMINATOR_HL_DEPLOY_WAIT_MS);
-    } catch (err) {
-        const hlB = await client.getBalance(highloadWallet.address).catch(() => 0n);
-        console.log(
-            `  ${err instanceof Error ? err.message : String(err)} · highload ${fromNano(hlB)} TON — not all nominators answered seqno after sendBatch within timeout; continuing (check RPC / balances / count).`,
-        );
-    }
-
     console.log(
         `  Next highload query id (local sequence after sendBatch; reuse same on-chain highload only with matching query id): ${highloadWallet.sequence.current()}`,
     );
     await new Promise((r) => setTimeout(r, 3000));
 
     console.log(
-        `  Waiting for all nominator wallets to become active (poll, max ${NOMINATOR_DEPLOY_WAIT_MS / 1000}s)…`,
+        `  Waiting for all nominator wallets to become active (poll, max ${SCRIPT_CHAIN_POLL_MAX_MS / 1000}s)…`,
     );
     try {
-        await waitUntilAllWalletsSeqnoReady(client, nominatorWallets, "deploy-wait", NOMINATOR_DEPLOY_WAIT_MS, {
+        await waitUntilAllWalletsSeqnoReady(client, nominatorWallets, "deploy-wait", SCRIPT_CHAIN_POLL_MAX_MS, {
             pollMs: 3000,
             logSuccess: false,
             onProgress: async (ready, total) => {
@@ -361,7 +343,7 @@ async function run() {
             ? `Highload balance ${fromNano(hlBal)} TON is low — top up the master and re-run (intended highload topup this run: ${fromNano(highloadTopup)} TON).`
             : `Highload still holds ${fromNano(hlBal)} TON — try lowering count if ton-http-api rejects large BOC (HTTP 500), or wait for the chain.`;
         throw new Error(
-            `Only ${ready}/${count} nominator wallets became active after ${NOMINATOR_DEPLOY_WAIT_MS} ms. ${hint} Stuck: ${stuck.join("; ")}`,
+            `Only ${ready}/${count} nominator wallets became active after ${SCRIPT_CHAIN_POLL_MAX_MS} ms. ${hint} Stuck: ${stuck.join("; ")}`,
         );
     }
     console.log(`  All ${count} nominator wallets active.`);

--- a/src/node/tests/test_load_net/scripts/add-nominators-to-pool.ts
+++ b/src/node/tests/test_load_net/scripts/add-nominators-to-pool.ts
@@ -4,6 +4,10 @@
  * Pool FunC (`pool.fc`): nominator deposit uses **`op == 0`**, **`action == 100`** ('d'), value in message.
  * **`throw_unless(61, sender_wc == 0)`** — nominators must use **basechain (workchain 0)** wallets, not masterchain.
  *
+ * CI / throughput: deploy+fund uses a **Highload Wallet v3** on masterchain (same key material as `MASTER_WALLET_KEY`)
+ * in **one** `sendBatch` external carrying all deploy+fund `internal` messages; stake messages are then sent **in parallel**
+ * from each nominator contract (each signs as its own V3R2). Large `count` / HTTP limits may return 500 — then raise gas / reduce N or use master-only path manually.
+ *
  * Usage:
  *   bun scripts/add-nominators-to-pool.ts <pool_address> [amount_ton] [count]
  *
@@ -21,10 +25,13 @@
  *   NOMINATOR_FUND_EXTRA_TON (default 0.15)
  *   POOL_INFO_DELAY_MS — wait before get_pool_data dump (default 5000)
  *   TONCORE_POOL_INFO_EXTRA — comma-separated extra pool addresses to print after (same API)
+ *
+ * Highload: each run starts `HighloadWalletV3.newSequence()`; reusing the same on-chain highload contract must match the next query id (see logged line after `sendBatch`).
  */
 import { TonClient } from "@ton/ton";
 import { Address, beginCell, fromNano, internal, SendMode, toNano } from "@ton/core";
 import { WalletContractV3R2 } from "@ton/ton";
+import { HighloadWalletV3 } from "@tonkite/highload-wallet-v3";
 import { checkEnvs } from "./utils";
 import {
     fetchMinNominatorStakeNano,
@@ -39,6 +46,15 @@ const DEFAULT_NOMINATOR_WORKCHAIN = 0;
 /** Attached TON per msg; must be >= on-chain min_nominator_stake + 1 TON pool fee (default min stake 10k → 10001). */
 const DEFAULT_STAKE_TON = "10001";
 const DEFAULT_POOL_INFO_DELAY_MS = 5000;
+
+/** Highload wallet timeout (seconds). */
+const HIGHLOAD_TIMEOUT_SEC = 60 * 60 * 24;
+/** After master→highload deploy/topup: poll until active and funded. */
+const HIGHLOAD_DEPLOY_FUND_WAIT_MS = 600_000;
+/** After highload `sendBatch`: wait until nominator wallets answer `seqno`. */
+const NOMINATOR_HL_DEPLOY_WAIT_MS = 600_000;
+/** Final poll until every nominator wallet is active. */
+const NOMINATOR_DEPLOY_WAIT_MS = 600_000;
 
 /** pool.fc: `op == 0`, `action == 100` ('d') */
 const TONCORE_ACTION_NOMINATOR_DEPOSIT = 100;
@@ -55,6 +71,77 @@ function uniqueAddresses(primary: Address, extras: Address[]): Address[] {
         }
     }
     return out;
+}
+
+
+/** Some HTTP stacks throw or return non-zero on get-method for missing/uninit accounts. */
+async function contractGetMethodOk(client: TonClient, address: Address, name: string): Promise<boolean> {
+    try {
+        const res = await client.runMethodWithError(address, name, []);
+        return res.exit_code === 0;
+    } catch {
+        return false;
+    }
+}
+
+/** One pass: who already answers `seqno` get-method (deployed/active) vs who does not yet. */
+async function classifyWalletsBySeqnoReadiness(
+    client: TonClient,
+    wallets: WalletContractV3R2[],
+): Promise<{ ready: number; withoutSeqno: WalletContractV3R2[] }> {
+    const withoutSeqno: WalletContractV3R2[] = [];
+    for (const w of wallets) {
+        if (await contractGetMethodOk(client, w.address, "seqno")) continue;
+        withoutSeqno.push(w);
+    }
+    return { ready: wallets.length - withoutSeqno.length, withoutSeqno };
+}
+
+/** Poll until each wallet answers get-method `seqno` (exit 0), or timeout. */
+async function waitUntilAllWalletsSeqnoReady(
+    client: TonClient,
+    wallets: WalletContractV3R2[],
+    label: string,
+    maxMs: number,
+    options?: {
+        pollMs?: number;
+        /** Called when not all ready yet, before sleeping until next poll. */
+        onProgress?: (ready: number, total: number) => void | Promise<void>;
+        logSuccess?: boolean;
+    },
+): Promise<void> {
+    const pollMs = options?.pollMs ?? 2500;
+    const t0 = Date.now();
+    while (Date.now() - t0 < maxMs) {
+        const { ready } = await classifyWalletsBySeqnoReadiness(client, wallets);
+        if (ready === wallets.length) {
+            if (options?.logSuccess !== false) {
+                console.log(`    "${label}": all ${wallets.length} wallet(s) active`);
+            }
+            return;
+        }
+        await options?.onProgress?.(ready, wallets.length);
+        await new Promise((r) => setTimeout(r, pollMs));
+    }
+    const { ready } = await classifyWalletsBySeqnoReadiness(client, wallets);
+    throw new Error(`"${label}": only ${ready}/${wallets.length} wallet(s) active within ${maxMs} ms`);
+}
+
+/** Calls `predicate` on an interval until it returns true or `timeoutMs`; if `predicate` throws, that tick counts as false and polling continues. */
+async function pollUntil(
+    label: string,
+    predicate: () => Promise<boolean>,
+    timeoutMs: number,
+    pollMs: number,
+): Promise<void> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+        if (await predicate().catch(() => false)) {
+            return;
+        }
+        await new Promise((r) => setTimeout(r, pollMs));
+    }
+    throw new Error(`Timeout waiting for: ${label} (${timeoutMs} ms)`);
 }
 
 async function run() {
@@ -102,7 +189,6 @@ async function run() {
         throw new Error("MASTER_WALLET_KEY must be 64 bytes (hex)");
     }
     const publicKey = masterKey.subarray(32);
-
     const masterWalletId = Number.parseInt(process.env.MASTER_WALLET_ID ?? "42", 10);
     const subwalletBase = Number.parseInt(process.env.NOMINATOR_SUBWALLET_BASE ?? String(DEFAULT_SUBWALLET_BASE), 10);
     const deployAndFees = toNano(process.env.NOMINATOR_FUND_EXTRA_TON ?? "0.15");
@@ -140,13 +226,20 @@ async function run() {
 
     const body = tonCoreNominatorDepositBody();
 
+    const highloadTopup = (deployAndFees + amountPer + toNano("1")) * BigInt(count);
+
+    const highloadWallet = new HighloadWalletV3(HighloadWalletV3.newSequence(), publicKey, HIGHLOAD_TIMEOUT_SEC, HighloadWalletV3.DEFAULT_SUBWALLET_ID, -1);
+
     console.log(`Master wallet: ${masterWallet.address.toString()} (walletId=${masterWalletId})`);
+    console.log(`Highload wallet (orchestrator, mc): ${highloadWallet.address.toString()} (subwalletId=${HighloadWalletV3.DEFAULT_SUBWALLET_ID}, DEFAULT_SUBWALLET_ID)`);
     console.log(
-        `Pool: ${poolAddr.toString()}, ${count} msgs × ${amountTon} TON, ` +
+        `Pool: ${poolAddr.toString()}, ${count} nominators × ${amountTon} TON, ` +
             `body op=0 action=${TONCORE_ACTION_NOMINATOR_DEPOSIT} ('d'), nominator wc=${nominatorWorkchain}, subwallet base=${subwalletBase}`,
     );
     console.log(`On-chain min_nominator_stake: ${fromNano(minNom)} TON`);
 
+    const nominatorWallets: WalletContractV3R2[] = [];
+    const batchMessages: { mode: SendMode; message: ReturnType<typeof internal> }[] = [];
     for (let i = 0; i < count; i++) {
         const subId = subwalletBase + i;
         const subW = WalletContractV3R2.create({
@@ -154,45 +247,146 @@ async function run() {
             publicKey,
             walletId: subId,
         });
-
+        nominatorWallets.push(subW);
         console.log(`[${i + 1}/${count}] nominator subwallet id=${subId} → ${subW.address.toString()}`);
-
-        const fundTotal = deployAndFees + amountPer;
-        const seqno = await master.getSeqno();
-        await master.sendTransfer({
-            seqno,
-            secretKey: masterKey,
-            messages: [
-                internal({
-                    to: subW.address,
-                    value: fundTotal,
-                    bounce: false,
-                    init: subW.init,
-                }),
-            ],
-            sendMode: SendMode.PAY_GAS_SEPARATELY,
+        batchMessages.push({
+            mode: SendMode.PAY_GAS_SEPARATELY,
+            message: internal({
+                to: subW.address,
+                value: deployAndFees + amountPer,
+                bounce: false,
+                init: subW.init,
+            }),
         });
-        console.log(`  deploy+fund ${fromNano(fundTotal)} TON, waiting…`);
-        await new Promise((r) => setTimeout(r, 3000));
-
-        const sub = client.open(subW);
-        const subSeqno = await sub.getSeqno();
-        await sub.sendTransfer({
-            seqno: subSeqno,
-            secretKey: masterKey,
-            messages: [
-                internal({
-                    to: poolAddr,
-                    value: amountPer,
-                    bounce: true,
-                    body,
-                }),
-            ],
-            sendMode: SendMode.PAY_GAS_SEPARATELY,
-        });
-        console.log(`  sent ${amountTon} TON (op=0 action=${TONCORE_ACTION_NOMINATOR_DEPOSIT})`);
-        await new Promise((r) => setTimeout(r, 1500));
     }
+
+    const totalOutFromHighload = (deployAndFees + amountPer) * BigInt(count);
+    const valuePerBatch = totalOutFromHighload + toNano("1");
+    /** Enough for `sendBatch` attach + headroom for MC deploy/import fees (not full nominal `highloadTopup`). */
+    const highloadFundedMinBalance = valuePerBatch + toNano("5");
+
+    const hlDeployed = await client.isContractDeployed(highloadWallet.address).catch(() => false);
+    const hlBalance = await client.getBalance(highloadWallet.address);
+
+    if (!hlDeployed || hlBalance < highloadFundedMinBalance) {
+        const seqno = await master.getSeqno();
+        try {
+            await master.sendTransfer({
+                seqno,
+                secretKey: masterKey,
+                messages: [
+                    internal({
+                        to: highloadWallet.address,
+                        value: highloadTopup,
+                        bounce: false,
+                        init: hlDeployed ? undefined : highloadWallet.init,
+                    }),
+                ],
+                sendMode: SendMode.PAY_GAS_SEPARATELY,
+            });
+        } catch (e) {
+            throw new Error(e instanceof Error ? e.message : String(e));
+        }
+        console.log(
+            hlDeployed
+                ? `  Topped up highload with ${fromNano(highloadTopup)} TON (deploy already active)`
+                : `  Deploy+fund highload with ${fromNano(highloadTopup)} TON, waiting…`,
+        );
+        await pollUntil(
+            "highload deployed + funded",
+            async () => {
+                if (!(await client.isContractDeployed(highloadWallet.address))) return false;
+                const b = await client.getBalance(highloadWallet.address);
+                return b >= highloadFundedMinBalance;
+            },
+            HIGHLOAD_DEPLOY_FUND_WAIT_MS,
+            2000,
+        );
+    }
+
+    const highloadContract = client.open(highloadWallet);
+    const createdAt = Math.floor(Date.now() / 1000) - 10;
+    console.log(`  Highload deploy+fund: one sendBatch with ${count} messages (single external)…`);
+    try {
+        await highloadContract.sendBatch(masterKey, {
+            messages: batchMessages,
+            valuePerBatch,
+            createdAt,
+        });
+    } catch (e) {
+        throw new Error(e instanceof Error ? e.message : String(e));
+    }
+    highloadWallet.sequence.next();
+    try {
+        await waitUntilAllWalletsSeqnoReady(client, nominatorWallets, "hl-deploy", NOMINATOR_HL_DEPLOY_WAIT_MS);
+    } catch (err) {
+        const hlB = await client.getBalance(highloadWallet.address).catch(() => 0n);
+        console.log(
+            `  ${err instanceof Error ? err.message : String(err)} · highload ${fromNano(hlB)} TON — not all nominators answered seqno after sendBatch within timeout; continuing (check RPC / balances / count).`,
+        );
+    }
+
+    console.log(
+        `  Next highload query id (local sequence after sendBatch; reuse same on-chain highload only with matching query id): ${highloadWallet.sequence.current()}`,
+    );
+    await new Promise((r) => setTimeout(r, 3000));
+
+    console.log(
+        `  Waiting for all nominator wallets to become active (poll, max ${NOMINATOR_DEPLOY_WAIT_MS / 1000}s)…`,
+    );
+    try {
+        await waitUntilAllWalletsSeqnoReady(client, nominatorWallets, "deploy-wait", NOMINATOR_DEPLOY_WAIT_MS, {
+            pollMs: 3000,
+            logSuccess: false,
+            onProgress: async (ready, total) => {
+                try {
+                    const hlB = await client.getBalance(highloadWallet.address);
+                    console.log(
+                        `  Nominator contracts ready (get seqno): ${ready}/${total} · highload balance ${fromNano(hlB)} TON`,
+                    );
+                } catch {
+                    console.log(`  Nominator contracts ready (get seqno): ${ready}/${total} · highload balance: RPC error`);
+                }
+            },
+        });
+    } catch {
+        const { ready, withoutSeqno } = await classifyWalletsBySeqnoReadiness(client, nominatorWallets);
+        const stuck = withoutSeqno.map((w) => {
+            const i = nominatorWallets.indexOf(w);
+            return `#${i + 1} ${w.address.toString()}`;
+        });
+        const hlBal = await client.getBalance(highloadWallet.address);
+        const lowHl = hlBal < toNano("50");
+        const hint = lowHl
+            ? `Highload balance ${fromNano(hlBal)} TON is low — top up the master and re-run (intended highload topup this run: ${fromNano(highloadTopup)} TON).`
+            : `Highload still holds ${fromNano(hlBal)} TON — try lowering count if ton-http-api rejects large BOC (HTTP 500), or wait for the chain.`;
+        throw new Error(
+            `Only ${ready}/${count} nominator wallets became active after ${NOMINATOR_DEPLOY_WAIT_MS} ms. ${hint} Stuck: ${stuck.join("; ")}`,
+        );
+    }
+    console.log(`  All ${count} nominator wallets active.`);
+
+    console.log(`  Sending ${count} stake transfers in parallel (each from its own nominator wallet)…`);
+    await Promise.all(
+        nominatorWallets.map(async (subW, idx) => {
+            const sub = client.open(subW);
+            const subSeqno = await sub.getSeqno();
+            await sub.sendTransfer({
+                seqno: subSeqno,
+                secretKey: masterKey,
+                messages: [
+                    internal({
+                        to: poolAddr,
+                        value: amountPer,
+                        bounce: true,
+                        body,
+                    }),
+                ],
+                sendMode: SendMode.PAY_GAS_SEPARATELY,
+            });
+            console.log(`  [${idx + 1}/${count}] sent ${amountTon} TON (op=0 action=${TONCORE_ACTION_NOMINATOR_DEPOSIT})`);
+        }),
+    );
 
     console.log("Done.");
     if (poolInfoDelayMs > 0) {

--- a/src/node/tests/test_load_net/scripts/topup.ts
+++ b/src/node/tests/test_load_net/scripts/topup.ts
@@ -59,7 +59,7 @@ async function run() {
     });
     console.log(`Sent ${fromNano(amount)} TON to ${address}, waiting for balance update...`);
 
-    const timeout = 30_000;
+    const timeout = 60_000;
     const poll = 1_000;
     const start = Date.now();
     while (Date.now() - start < timeout) {

--- a/src/node/tests/test_run_net_py/run_singlehost_nodectl.py
+++ b/src/node/tests/test_run_net_py/run_singlehost_nodectl.py
@@ -4,7 +4,7 @@ One-button bootstrap for local singlehost TON network + nodectl service.
 
 Supports multiple pool topologies via the SCENARIO env var:
   - "default"      — 5 SNP + 1 TONCore (NODE_CNT=6, CORE_COUNT=1)
-  - "snp-toncore"  — 2 SNP + 5 TONCore, split50, election observation (NODE_CNT=7, CORE_COUNT=5)
+  - "snp-toncore"  — 2 SNP + 3 TONCore, split50, election observation (NODE_CNT=5, CORE_COUNT=3)
 
 Individual env vars (NODE_CNT, CORE_COUNT, OBSERVE_ROUNDS, STAKE_POLICY, etc.)
 override scenario defaults.
@@ -69,7 +69,8 @@ from typing import Optional
 
 # ── Constants ──────────────────────────────────────────────────────────────────
 ELECTOR_ADDR    = "-1:3333333333333333333333333333333333333333333333333333333333333333"
-WALLET_VERSIONS = ["V1R3", "V3R2", "V4R2", "V5R1", "V3R2", "V3R2", "V4R2"]
+# One entry per node index (node1..); default scenario uses up to 6 nodes, snp-toncore up to 5.
+WALLET_VERSIONS = ["V1R3", "V3R2", "V4R2", "V5R1", "V3R2", "V3R2"]
 
 _STRIP_ANSI_CSI = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
 
@@ -89,8 +90,8 @@ SCENARIOS: dict[str, dict] = {
         "toncore_validator_deposit_ton": 100_100,
     },
     "snp-toncore": {
-        "node_cnt": 7,
-        "core_count": 5,
+        "node_cnt": 5,
+        "core_count": 3,
         "observe_rounds": 4,
         "observe_interval_sec": 20,
         "stake_policy": "split50",
@@ -525,11 +526,12 @@ class Bootstrap:
             return ""
 
     def _bun_topup(self, address: str, amount: str) -> None:
-        timeout_raw = os.environ.get("BUN_TOPUP_TIMEOUT_SECONDS", "120")
+        # Must be >= scripts/topup.ts balance wait (default TOPUP_BALANCE_WAIT_MS 300s) + margin.
+        timeout_raw = os.environ.get("BUN_TOPUP_TIMEOUT_SECONDS", "400")
         try:
             timeout = int(timeout_raw)
         except ValueError:
-            timeout = 120
+            timeout = 400
         subprocess.run(["bun", "run", "topup", address, amount],
                        cwd=self.paths.load_net_dir, check=True,
                        stdin=subprocess.DEVNULL, timeout=timeout)

--- a/src/node/tests/test_run_net_py/run_singlehost_nodectl.py
+++ b/src/node/tests/test_run_net_py/run_singlehost_nodectl.py
@@ -69,7 +69,6 @@ from typing import Optional
 
 # ── Constants ──────────────────────────────────────────────────────────────────
 ELECTOR_ADDR    = "-1:3333333333333333333333333333333333333333333333333333333333333333"
-# One entry per node index (node1..); default scenario uses up to 6 nodes, snp-toncore up to 5.
 WALLET_VERSIONS = ["V1R3", "V3R2", "V4R2", "V5R1", "V3R2", "V3R2"]
 
 _STRIP_ANSI_CSI = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
@@ -526,7 +525,7 @@ class Bootstrap:
             return ""
 
     def _bun_topup(self, address: str, amount: str) -> None:
-        # Must be >= scripts/topup.ts balance wait (default TOPUP_BALANCE_WAIT_MS 300s) + margin.
+        # Keep subprocess timeout above topup.ts post-send balance poll (60s hardcoded) + margin.
         timeout_raw = os.environ.get("BUN_TOPUP_TIMEOUT_SECONDS", "400")
         try:
             timeout = int(timeout_raw)


### PR DESCRIPTION
## Summary
This change speeds up TONCore multi-nominator setup by routing deploy-and-fund through a masterchain Highload Wallet v3 in add-nominators-to-pool (single sendBatch for all nominator wallet deploys, then parallel stake sends from each V3R2 subwallet). The single-host bootstrap scenario is tightened by lowering the node count from 7 to 5 so the scripted run stays lighter while still covering SNP + TONCore + elections behavior.

## Changes
-`src/node/tests/test_load_net/scripts/add-nominators-to-pool.ts` — Add Highload-based path: fund/deploy highload from the master wallet, poll until the highload contract is live and holds enough balance for the upcoming sendBatch (threshold tied to valuePerBatch plus a small fee headroom instead of the full nominal top-up minus 1 TON), then one sendBatch of all nominator deploy+fund internals; keep existing pool deposit flow and timeouts for seqno / deploy waits.

-`src/node/tests/test_run_net_py/run_singlehost_nodectl.py` — Update the scenario / NODE_CNT (or equivalent) from 7 to 5 for the scripted single-host layout; align docstrings/comments and any logic that assumes the old node count (e.g. pool slot mapping, test_run_net.json generation, phase loops over node1..nodeN).

-`src/node/tests/test_load_net/scripts/topup.ts`— Extend the post-transfer balance poll timeout (e.g. 30s → 60s) so slow RPC / indexing does not fail pool top-ups during bootstrap.