### PR TITLE
feat: add tests for entity CRUD REST API endpoints

### DIFF
--- a/src/node-control/service/src/http/auth_tests.rs
+++ b/src/node-control/service/src/http/auth_tests.rs
@@ -21,7 +21,15 @@ use common::{
     task_cancellation::CancellationCtx,
 };
 use http_body_util::BodyExt;
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::{SystemTime, UNIX_EPOCH},
+};
 use tower::ServiceExt;
 
 struct Noop;
@@ -109,13 +117,29 @@ fn elections_task(rt: Arc<RuntimeConfigStore>) -> Arc<TaskController> {
 
 const TEST_JWT_SECRET: &str = "KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKio="; // [42u8; 32]
 
+/// Unique path under the system temp dir so parallel auth tests never share `save_to_file` output.
+fn unique_test_config_path() -> PathBuf {
+    static NEXT_ID: AtomicU64 = AtomicU64::new(0);
+    let unique_id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+    std::env::temp_dir().join(format!(
+        "node-control-auth-tests-{}-{}-{}.json",
+        std::process::id(),
+        nanos,
+        unique_id
+    ))
+}
+
 async fn test_jwt_auth() -> Arc<JwtAuth> {
     Arc::new(JwtAuth::new(None, Some(TEST_JWT_SECRET)).await.unwrap())
 }
 
 async fn state_with_auth() -> AppState {
     let cfg = auth_config();
-    let rt = Arc::new(RuntimeConfigStore::from_app_config(app_cfg_with_auth(cfg.clone())));
+    let rt = Arc::new(RuntimeConfigStore::from_app_config_with_path(
+        app_cfg_with_auth(cfg.clone()),
+        unique_test_config_path().to_string_lossy().into_owned(),
+    ));
     AppState {
         store: Arc::new(SnapshotStore::new()),
         runtime_cfg: rt.clone(),
@@ -128,7 +152,10 @@ async fn state_with_auth() -> AppState {
 }
 
 async fn state_no_auth() -> AppState {
-    let rt = Arc::new(RuntimeConfigStore::from_app_config(app_cfg_no_auth()));
+    let rt = Arc::new(RuntimeConfigStore::from_app_config_with_path(
+        app_cfg_no_auth(),
+        unique_test_config_path().to_string_lossy().into_owned(),
+    ));
     AppState {
         store: Arc::new(SnapshotStore::new()),
         runtime_cfg: rt.clone(),

--- a/src/node-control/service/src/http/auth_tests.rs
+++ b/src/node-control/service/src/http/auth_tests.rs
@@ -180,6 +180,15 @@ fn post_bearer(uri: &str, body: &impl serde::Serialize, token: &str) -> axum::ht
         .unwrap()
 }
 
+fn delete_bearer(uri: &str, token: &str) -> axum::http::Request<Body> {
+    axum::http::Request::builder()
+        .method("DELETE")
+        .uri(uri)
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap()
+}
+
 // --- Login flow ---
 
 #[tokio::test]
@@ -344,6 +353,95 @@ async fn nominator_forbidden_on_operator_route() {
     let body = serde_json::json!({ "policy": "minimum" });
     let resp = app(st).oneshot(post_bearer("/v1/elections/settings", &body, &tok)).await.unwrap();
     assert_eq!(resp.status(), 403);
+}
+
+#[tokio::test]
+async fn nominator_forbidden_on_entity_crud_routes() {
+    let st = state_with_auth().await;
+    let tok = st.jwt_auth.generate("nom", Role::Nominator, 3600).unwrap().0;
+    let app = app(st);
+
+    let pubkey = base64::engine::general_purpose::STANDARD.encode([1u8; 32]);
+    let node_body = serde_json::json!({
+        "name": "n",
+        "control_server_endpoint": "127.0.0.1:1",
+        "control_server_pubkey": pubkey,
+        "control_client_secret": "s",
+    });
+    let wallet_body = serde_json::json!({
+        "name": "w",
+        "secret": "sec",
+        "version": "V4R2",
+        "subwallet_id": 0,
+        "workchain": -1,
+    });
+    let pool_body = serde_json::json!({
+        "name": "p",
+        "address": "-1:bd313e9e1114bbbe7af6f28ef59be0ff3f02ac795423f10397a70dc16396c4ea",
+        "owner": serde_json::Value::Null,
+    });
+    let binding_body = serde_json::json!({
+        "node": "n",
+        "wallet": "w",
+        "pool": serde_json::Value::Null,
+    });
+
+    assert_eq!(
+        app.clone().oneshot(post_bearer("/v1/nodes", &node_body, &tok)).await.unwrap().status(),
+        403
+    );
+    assert_eq!(
+        app.clone().oneshot(delete_bearer("/v1/nodes/any", &tok)).await.unwrap().status(),
+        403
+    );
+    assert_eq!(
+        app.clone().oneshot(post_bearer("/v1/wallets", &wallet_body, &tok)).await.unwrap().status(),
+        403
+    );
+    assert_eq!(
+        app.clone().oneshot(delete_bearer("/v1/wallets/any", &tok)).await.unwrap().status(),
+        403
+    );
+    assert_eq!(
+        app.clone().oneshot(post_bearer("/v1/pools", &pool_body, &tok)).await.unwrap().status(),
+        403
+    );
+    assert_eq!(
+        app.clone().oneshot(delete_bearer("/v1/pools/any", &tok)).await.unwrap().status(),
+        403
+    );
+    assert_eq!(
+        app.clone()
+            .oneshot(post_bearer("/v1/bindings", &binding_body, &tok))
+            .await
+            .unwrap()
+            .status(),
+        403
+    );
+    assert_eq!(
+        app.clone().oneshot(delete_bearer("/v1/bindings/any", &tok)).await.unwrap().status(),
+        403
+    );
+}
+
+#[tokio::test]
+async fn operator_can_mutate_entity_crud_when_auth_enabled() {
+    let st = state_with_auth().await;
+    let tok = st.jwt_auth.generate("op", Role::Operator, 3600).unwrap().0;
+    let app = app(st);
+
+    let pubkey = base64::engine::general_purpose::STANDARD.encode([2u8; 32]);
+    let node_body = serde_json::json!({
+        "name": "op_node",
+        "control_server_endpoint": "127.0.0.1:3039",
+        "control_server_pubkey": pubkey,
+        "control_client_secret": "op_sec",
+    });
+    let resp = app.clone().oneshot(post_bearer("/v1/nodes", &node_body, &tok)).await.unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let resp = app.oneshot(delete_bearer("/v1/nodes/op_node", &tok)).await.unwrap();
+    assert_eq!(resp.status(), 200);
 }
 
 #[tokio::test]

--- a/src/node-control/service/src/http/auth_tests.rs
+++ b/src/node-control/service/src/http/auth_tests.rs
@@ -21,16 +21,10 @@ use common::{
     task_cancellation::CancellationCtx,
 };
 use http_body_util::BodyExt;
-use std::{
-    collections::HashMap,
-    path::PathBuf,
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::{collections::HashMap, sync::Arc};
 use tower::ServiceExt;
+
+const TEST_JWT_SECRET: &str = "KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKio="; // [42u8; 32]
 
 struct Noop;
 
@@ -45,6 +39,51 @@ impl ServiceTask for Noop {
         let _ = c.changed().await;
         Ok(())
     }
+}
+
+async fn json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+fn get(uri: &str) -> axum::http::Request<Body> {
+    axum::http::Request::builder().uri(uri).body(Body::empty()).unwrap()
+}
+
+fn get_bearer(uri: &str, token: &str) -> axum::http::Request<Body> {
+    axum::http::Request::builder()
+        .uri(uri)
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap()
+}
+
+fn post_json(uri: &str, body: &impl serde::Serialize) -> axum::http::Request<Body> {
+    axum::http::Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_string(body).unwrap()))
+        .unwrap()
+}
+
+fn post_bearer(uri: &str, body: &impl serde::Serialize, token: &str) -> axum::http::Request<Body> {
+    axum::http::Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::from(serde_json::to_string(body).unwrap()))
+        .unwrap()
+}
+
+fn delete_bearer(uri: &str, token: &str) -> axum::http::Request<Body> {
+    axum::http::Request::builder()
+        .method("DELETE")
+        .uri(uri)
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap()
 }
 
 fn hash_test_password(password: &[u8]) -> String {
@@ -115,31 +154,13 @@ fn elections_task(rt: Arc<RuntimeConfigStore>) -> Arc<TaskController> {
     Arc::new(TaskController::new("elections", Noop, rt))
 }
 
-const TEST_JWT_SECRET: &str = "KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKio="; // [42u8; 32]
-
-/// Unique path under the system temp dir so parallel auth tests never share `save_to_file` output.
-fn unique_test_config_path() -> PathBuf {
-    static NEXT_ID: AtomicU64 = AtomicU64::new(0);
-    let unique_id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
-    let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
-    std::env::temp_dir().join(format!(
-        "node-control-auth-tests-{}-{}-{}.json",
-        std::process::id(),
-        nanos,
-        unique_id
-    ))
-}
-
 async fn test_jwt_auth() -> Arc<JwtAuth> {
     Arc::new(JwtAuth::new(None, Some(TEST_JWT_SECRET)).await.unwrap())
 }
 
 async fn state_with_auth() -> AppState {
     let cfg = auth_config();
-    let rt = Arc::new(RuntimeConfigStore::from_app_config_with_path(
-        app_cfg_with_auth(cfg.clone()),
-        unique_test_config_path().to_string_lossy().into_owned(),
-    ));
+    let rt = Arc::new(RuntimeConfigStore::from_app_config(app_cfg_with_auth(cfg.clone())));
     AppState {
         store: Arc::new(SnapshotStore::new()),
         runtime_cfg: rt.clone(),
@@ -152,10 +173,7 @@ async fn state_with_auth() -> AppState {
 }
 
 async fn state_no_auth() -> AppState {
-    let rt = Arc::new(RuntimeConfigStore::from_app_config_with_path(
-        app_cfg_no_auth(),
-        unique_test_config_path().to_string_lossy().into_owned(),
-    ));
+    let rt = Arc::new(RuntimeConfigStore::from_app_config(app_cfg_no_auth()));
     AppState {
         store: Arc::new(SnapshotStore::new()),
         runtime_cfg: rt.clone(),
@@ -171,49 +189,67 @@ fn app(st: AppState) -> axum::Router {
     routes(false, st)
 }
 
-async fn json(resp: axum::response::Response) -> serde_json::Value {
-    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
-    serde_json::from_slice(&bytes).unwrap()
+/// Method + path + optional JSON body. Used by the role-gating tables below.
+fn entity_crud_routes() -> Vec<(&'static str, &'static str, Option<serde_json::Value>)> {
+    let pubkey = base64::engine::general_purpose::STANDARD.encode([1u8; 32]);
+    vec![
+        (
+            "POST",
+            "/v1/nodes",
+            Some(serde_json::json!({
+                "name": "n",
+                "control_server_endpoint": "127.0.0.1:1",
+                "control_server_pubkey": pubkey,
+                "control_client_secret": "s",
+            })),
+        ),
+        ("DELETE", "/v1/nodes/any", None),
+        (
+            "POST",
+            "/v1/wallets",
+            Some(serde_json::json!({
+                "name": "w",
+                "secret": "sec",
+                "version": "V4R2",
+                "subwallet_id": 0,
+                "workchain": -1,
+            })),
+        ),
+        ("DELETE", "/v1/wallets/any", None),
+        (
+            "POST",
+            "/v1/pools",
+            Some(serde_json::json!({
+                "name": "p",
+                "address": "-1:bd313e9e1114bbbe7af6f28ef59be0ff3f02ac795423f10397a70dc16396c4ea",
+                "owner": serde_json::Value::Null,
+            })),
+        ),
+        ("DELETE", "/v1/pools/any", None),
+        (
+            "POST",
+            "/v1/bindings",
+            Some(serde_json::json!({
+                "node": "n",
+                "wallet": "w",
+                "pool": serde_json::Value::Null,
+            })),
+        ),
+        ("DELETE", "/v1/bindings/any", None),
+    ]
 }
 
-fn get(uri: &str) -> axum::http::Request<Body> {
-    axum::http::Request::builder().uri(uri).body(Body::empty()).unwrap()
-}
-
-fn get_bearer(uri: &str, token: &str) -> axum::http::Request<Body> {
-    axum::http::Request::builder()
-        .uri(uri)
-        .header("Authorization", format!("Bearer {token}"))
-        .body(Body::empty())
-        .unwrap()
-}
-
-fn post_json(uri: &str, body: &impl serde::Serialize) -> axum::http::Request<Body> {
-    axum::http::Request::builder()
-        .method("POST")
-        .uri(uri)
-        .header("content-type", "application/json")
-        .body(Body::from(serde_json::to_string(body).unwrap()))
-        .unwrap()
-}
-
-fn post_bearer(uri: &str, body: &impl serde::Serialize, token: &str) -> axum::http::Request<Body> {
-    axum::http::Request::builder()
-        .method("POST")
-        .uri(uri)
-        .header("content-type", "application/json")
-        .header("Authorization", format!("Bearer {token}"))
-        .body(Body::from(serde_json::to_string(body).unwrap()))
-        .unwrap()
-}
-
-fn delete_bearer(uri: &str, token: &str) -> axum::http::Request<Body> {
-    axum::http::Request::builder()
-        .method("DELETE")
-        .uri(uri)
-        .header("Authorization", format!("Bearer {token}"))
-        .body(Body::empty())
-        .unwrap()
+fn request_bearer(
+    method: &str,
+    uri: &str,
+    body: Option<&serde_json::Value>,
+    token: &str,
+) -> axum::http::Request<Body> {
+    match (method, body) {
+        ("POST", Some(b)) => post_bearer(uri, b, token),
+        ("DELETE", None) => delete_bearer(uri, token),
+        _ => panic!("unsupported request: method={method} body={}", body.is_some()),
+    }
 }
 
 // --- Login flow ---
@@ -388,87 +424,27 @@ async fn nominator_forbidden_on_entity_crud_routes() {
     let tok = st.jwt_auth.generate("nom", Role::Nominator, 3600).unwrap().0;
     let app = app(st);
 
-    let pubkey = base64::engine::general_purpose::STANDARD.encode([1u8; 32]);
-    let node_body = serde_json::json!({
-        "name": "n",
-        "control_server_endpoint": "127.0.0.1:1",
-        "control_server_pubkey": pubkey,
-        "control_client_secret": "s",
-    });
-    let wallet_body = serde_json::json!({
-        "name": "w",
-        "secret": "sec",
-        "version": "V4R2",
-        "subwallet_id": 0,
-        "workchain": -1,
-    });
-    let pool_body = serde_json::json!({
-        "name": "p",
-        "address": "-1:bd313e9e1114bbbe7af6f28ef59be0ff3f02ac795423f10397a70dc16396c4ea",
-        "owner": serde_json::Value::Null,
-    });
-    let binding_body = serde_json::json!({
-        "node": "n",
-        "wallet": "w",
-        "pool": serde_json::Value::Null,
-    });
-
-    assert_eq!(
-        app.clone().oneshot(post_bearer("/v1/nodes", &node_body, &tok)).await.unwrap().status(),
-        403
-    );
-    assert_eq!(
-        app.clone().oneshot(delete_bearer("/v1/nodes/any", &tok)).await.unwrap().status(),
-        403
-    );
-    assert_eq!(
-        app.clone().oneshot(post_bearer("/v1/wallets", &wallet_body, &tok)).await.unwrap().status(),
-        403
-    );
-    assert_eq!(
-        app.clone().oneshot(delete_bearer("/v1/wallets/any", &tok)).await.unwrap().status(),
-        403
-    );
-    assert_eq!(
-        app.clone().oneshot(post_bearer("/v1/pools", &pool_body, &tok)).await.unwrap().status(),
-        403
-    );
-    assert_eq!(
-        app.clone().oneshot(delete_bearer("/v1/pools/any", &tok)).await.unwrap().status(),
-        403
-    );
-    assert_eq!(
-        app.clone()
-            .oneshot(post_bearer("/v1/bindings", &binding_body, &tok))
-            .await
-            .unwrap()
-            .status(),
-        403
-    );
-    assert_eq!(
-        app.clone().oneshot(delete_bearer("/v1/bindings/any", &tok)).await.unwrap().status(),
-        403
-    );
+    for (method, path, body) in entity_crud_routes() {
+        let req = request_bearer(method, path, body.as_ref(), &tok);
+        let status = app.clone().oneshot(req).await.unwrap().status();
+        assert_eq!(status, 403, "endpoint {method} {path} leaked to nominator");
+    }
 }
 
 #[tokio::test]
-async fn operator_can_mutate_entity_crud_when_auth_enabled() {
+async fn operator_allowed_on_entity_crud_routes() {
+    // Auth-gate check: every entity-CRUD route must let an operator token through.
+    // The handler may then return 200/400/404 depending on state — we only care
+    // that the role middleware does not return 403.
     let st = state_with_auth().await;
     let tok = st.jwt_auth.generate("op", Role::Operator, 3600).unwrap().0;
     let app = app(st);
 
-    let pubkey = base64::engine::general_purpose::STANDARD.encode([2u8; 32]);
-    let node_body = serde_json::json!({
-        "name": "op_node",
-        "control_server_endpoint": "127.0.0.1:3039",
-        "control_server_pubkey": pubkey,
-        "control_client_secret": "op_sec",
-    });
-    let resp = app.clone().oneshot(post_bearer("/v1/nodes", &node_body, &tok)).await.unwrap();
-    assert_eq!(resp.status(), 200);
-
-    let resp = app.oneshot(delete_bearer("/v1/nodes/op_node", &tok)).await.unwrap();
-    assert_eq!(resp.status(), 200);
+    for (method, path, body) in entity_crud_routes() {
+        let req = request_bearer(method, path, body.as_ref(), &tok);
+        let status = app.clone().oneshot(req).await.unwrap().status();
+        assert_ne!(status, 403, "endpoint {method} {path} blocked operator (status={status})");
+    }
 }
 
 #[tokio::test]

--- a/src/node-control/service/src/http/config_handlers.rs
+++ b/src/node-control/service/src/http/config_handlers.rs
@@ -29,7 +29,7 @@ use ton_block::MsgAddressInt;
 use ton_http_api_client::v2::client_json_rpc::ClientJsonRpc;
 
 /// `type_id` for ADNL public keys (Ed25519).
-pub(crate) const ADNL_PUBKEY_TYPE_ID: i32 = 1209251014;
+const ADNL_PUBKEY_TYPE_ID: i32 = 1209251014;
 
 /// Logical name reserved for the master wallet entry; cannot be used as a regular wallet name.
 const MASTER_WALLET_RESERVED_NAME: &str = "master_wallet";

--- a/src/node-control/service/src/http/config_handlers.rs
+++ b/src/node-control/service/src/http/config_handlers.rs
@@ -29,7 +29,7 @@ use ton_block::MsgAddressInt;
 use ton_http_api_client::v2::client_json_rpc::ClientJsonRpc;
 
 /// `type_id` for ADNL public keys (Ed25519).
-const ADNL_PUBKEY_TYPE_ID: i32 = 1209251014;
+pub(crate) const ADNL_PUBKEY_TYPE_ID: i32 = 1209251014;
 
 /// Logical name reserved for the master wallet entry; cannot be used as a regular wallet name.
 const MASTER_WALLET_RESERVED_NAME: &str = "master_wallet";

--- a/src/node-control/service/src/http/entity_crud_handlers_tests.rs
+++ b/src/node-control/service/src/http/entity_crud_handlers_tests.rs
@@ -9,13 +9,12 @@
 //! REST mutation tests for `/v1/nodes`, `/v1/wallets`, `/v1/pools`, `/v1/bindings`.
 use crate::{
     auth::{jwt::JwtAuth, user_store::UserStore},
-    http::{config_handlers::ADNL_PUBKEY_TYPE_ID, http_server_task::*},
+    http::http_server_task::*,
     runtime_config::{RuntimeConfig, RuntimeConfigStore},
     task::task_manager::{ServiceTask, TaskController},
 };
 use adnl::common::Timeouts;
 use axum::body::Body;
-use base64::Engine;
 use common::{
     TonWalletVersion,
     app_config::{
@@ -26,16 +25,10 @@ use common::{
     task_cancellation::CancellationCtx,
 };
 use http_body_util::BodyExt;
-use std::{
-    collections::HashMap,
-    path::PathBuf,
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::{collections::HashMap, sync::Arc};
 use tower::ServiceExt;
+
+const TEST_JWT_SECRET: &str = "KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKio="; // [42u8; 32]
 
 struct Noop;
 
@@ -48,10 +41,35 @@ impl ServiceTask for Noop {
     }
 }
 
-const TEST_JWT_SECRET: &str = "KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKio="; // [42u8; 32]
+async fn json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).unwrap()
+}
 
-fn empty_app_cfg() -> Arc<AppConfig> {
-    Arc::new(AppConfig {
+fn get(uri: &str) -> axum::http::Request<Body> {
+    axum::http::Request::builder().uri(uri).body(Body::empty()).unwrap()
+}
+
+fn post_json(uri: &str, body: &impl serde::Serialize) -> axum::http::Request<Body> {
+    axum::http::Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_string(body).unwrap()))
+        .unwrap()
+}
+
+fn delete(uri: &str) -> axum::http::Request<Body> {
+    axum::http::Request::builder().method("DELETE").uri(uri).body(Body::empty()).unwrap()
+}
+
+/// Local copy of the ADNL Ed25519 type_id. Kept in sync with `config_handlers::ADNL_PUBKEY_TYPE_ID`
+/// — the value is never round-tripped through the prod code path, so a duplicate constant in tests
+/// is fine and avoids widening crate-internal visibility.
+const ADNL_PUBKEY_TYPE_ID: i32 = 1209251014;
+
+fn empty_app_cfg() -> AppConfig {
+    AppConfig {
         nodes: HashMap::new(),
         wallets: HashMap::new(),
         pools: HashMap::new(),
@@ -63,10 +81,11 @@ fn empty_app_cfg() -> Arc<AppConfig> {
         master_wallet: None,
         tick_interval: 30,
         log: Some(Default::default()),
-    })
+    }
 }
 
 fn valid_control_server_pubkey_b64() -> String {
+    use base64::Engine;
     base64::engine::general_purpose::STANDARD.encode([11u8; 32])
 }
 
@@ -107,27 +126,8 @@ fn sample_snp_pool(name: &str) -> (String, PoolConfig) {
     )
 }
 
-fn unique_test_config_path() -> PathBuf {
-    static NEXT_ID: AtomicU64 = AtomicU64::new(0);
-    let unique_id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
-    let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
-    std::env::temp_dir().join(format!(
-        "node-control-entity-crud-tests-{}-{}-{}.json",
-        std::process::id(),
-        nanos,
-        unique_id
-    ))
-}
-
-/// Builds [`AppState`] for router tests. Uses a unique temp config path so parallel tests never
-/// share `save_to_file` output (the default `from_app_config` `"noop"` path is unsuitable under
-/// `cargo test -- --test-threads=N`).
-async fn app_state(cfg: Arc<AppConfig>, config_path: Option<PathBuf>) -> AppState {
-    let path = config_path.unwrap_or_else(unique_test_config_path);
-    let rt = Arc::new(RuntimeConfigStore::from_app_config_with_path(
-        cfg,
-        path.to_string_lossy().into_owned(),
-    ));
+async fn app_state(cfg: AppConfig) -> AppState {
+    let rt = Arc::new(RuntimeConfigStore::from_app_config(Arc::new(cfg)));
     let jwt_auth = Arc::new(JwtAuth::new(None, Some(TEST_JWT_SECRET)).await.unwrap());
     AppState {
         store: Arc::new(SnapshotStore::new()),
@@ -140,27 +140,25 @@ async fn app_state(cfg: Arc<AppConfig>, config_path: Option<PathBuf>) -> AppStat
     }
 }
 
-async fn json(resp: axum::response::Response) -> serde_json::Value {
-    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
-    serde_json::from_slice(&bytes).unwrap()
+/// Test-only state where mutations are persisted to `path` (TempDir-managed by caller).
+async fn app_state_with_path(cfg: AppConfig, path: std::path::PathBuf) -> AppState {
+    let rt = Arc::new(
+        RuntimeConfigStore::from_app_config(Arc::new(cfg))
+            .with_path(path.to_string_lossy().into_owned()),
+    );
+    let jwt_auth = Arc::new(JwtAuth::new(None, Some(TEST_JWT_SECRET)).await.unwrap());
+    AppState {
+        store: Arc::new(SnapshotStore::new()),
+        runtime_cfg: rt.clone(),
+        elections_task: Arc::new(TaskController::new("elections", Noop, rt.clone())),
+        jwt_auth,
+        user_store: Arc::new(UserStore::new(rt as Arc<dyn RuntimeConfig>)),
+        login_rate_limiter: Arc::new(tokio::sync::Mutex::new(Default::default())),
+        config_changed: Arc::new(tokio::sync::Notify::new()),
+    }
 }
 
-fn get(uri: &str) -> axum::http::Request<Body> {
-    axum::http::Request::builder().uri(uri).body(Body::empty()).unwrap()
-}
-
-fn post_json(uri: &str, body: &impl serde::Serialize) -> axum::http::Request<Body> {
-    axum::http::Request::builder()
-        .method("POST")
-        .uri(uri)
-        .header("content-type", "application/json")
-        .body(Body::from(serde_json::to_string(body).unwrap()))
-        .unwrap()
-}
-
-fn delete(uri: &str) -> axum::http::Request<Body> {
-    axum::http::Request::builder().method("DELETE").uri(uri).body(Body::empty()).unwrap()
-}
+const POOL_ADDR_A: &str = "-1:bd313e9e1114bbbe7af6f28ef59be0ff3f02ac795423f10397a70dc16396c4ea";
 
 fn node_add_json(name: &str) -> serde_json::Value {
     serde_json::json!({
@@ -201,7 +199,7 @@ fn binding_add_json(node: &str, wallet: &str, pool: Option<&str>) -> serde_json:
 
 #[tokio::test]
 async fn nodes_post_succeeds() {
-    let st = app_state(empty_app_cfg(), None).await;
+    let st = app_state(empty_app_cfg()).await;
     let app = routes(false, st);
     let resp = app.clone().oneshot(post_json("/v1/nodes", &node_add_json("node_a"))).await.unwrap();
     assert_eq!(resp.status(), 200);
@@ -223,7 +221,7 @@ async fn nodes_post_succeeds() {
 
 #[tokio::test]
 async fn nodes_post_duplicate() {
-    let st = app_state(empty_app_cfg(), None).await;
+    let st = app_state(empty_app_cfg()).await;
     let app = routes(false, st);
     let body = node_add_json("dup_node");
     let resp = app.clone().oneshot(post_json("/v1/nodes", &body)).await.unwrap();
@@ -236,38 +234,37 @@ async fn nodes_post_duplicate() {
 
 #[tokio::test]
 async fn nodes_post_invalid_pubkey_base64() {
-    let st = app_state(empty_app_cfg(), None).await;
+    let st = app_state(empty_app_cfg()).await;
     let app = routes(false, st);
-    let body = serde_json::json!({
-        "name": "n_bad_pk",
-        "control_server_endpoint": "127.0.0.1:1",
-        "control_server_pubkey": "not-valid-base64!!!",
-        "control_client_secret": "sec",
-    });
+    let mut body = node_add_json("n_bad_pk");
+    body["control_server_pubkey"] = "not-valid-base64!!!".into();
     let resp = app.oneshot(post_json("/v1/nodes", &body)).await.unwrap();
     assert_eq!(resp.status(), 400);
     let v = json(resp).await;
     assert!(v["error"]["message"].as_str().unwrap().contains("base64"));
 }
 
+// --- DELETE /v1/nodes ---
+
 #[tokio::test]
-async fn nodes_delete_succeeds_then_not_found() {
-    let st = app_state(empty_app_cfg(), None).await;
+async fn nodes_delete_succeeds() {
+    let st = app_state(empty_app_cfg()).await;
     let app = routes(false, st);
-    let body = node_add_json("to_rm");
-    let resp = app.clone().oneshot(post_json("/v1/nodes", &body)).await.unwrap();
-    assert_eq!(resp.status(), 200);
-
-    let resp = app.clone().oneshot(delete("/v1/nodes/to_rm")).await.unwrap();
-    assert_eq!(resp.status(), 200);
-
+    app.clone().oneshot(post_json("/v1/nodes", &node_add_json("to_rm"))).await.unwrap();
     let resp = app.oneshot(delete("/v1/nodes/to_rm")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+#[tokio::test]
+async fn nodes_delete_not_found() {
+    let st = app_state(empty_app_cfg()).await;
+    let resp = routes(false, st).oneshot(delete("/v1/nodes/missing")).await.unwrap();
     assert_eq!(resp.status(), 404);
 }
 
 #[tokio::test]
-async fn nodes_delete_referenced_by_binding() {
-    let mut cfg = (*empty_app_cfg()).clone();
+async fn nodes_delete_rejected_when_referenced_by_binding() {
+    let mut cfg = empty_app_cfg();
     let (nname, ncfg) = sample_node_adnl("bound");
     cfg.nodes.insert(nname.clone(), ncfg);
     let (wname, wcfg) = sample_wallet("bw");
@@ -276,19 +273,19 @@ async fn nodes_delete_referenced_by_binding() {
         nname.clone(),
         NodeBinding { wallet: wname, pool: None, enable: false, status: BindingStatus::Idle },
     );
-    let st = app_state(Arc::new(cfg), None).await;
+    let st = app_state(cfg).await;
     let app = routes(false, st);
     let resp = app.oneshot(delete(&format!("/v1/nodes/{nname}"))).await.unwrap();
     assert_eq!(resp.status(), 400);
     let v = json(resp).await;
-    assert!(v["error"]["message"].as_str().unwrap().contains("binding"));
+    assert!(v["error"]["message"].as_str().unwrap().contains("referenced by a binding"));
 }
 
-// --- POST/DELETE /v1/wallets ---
+// --- POST /v1/wallets ---
 
 #[tokio::test]
 async fn wallets_post_succeeds() {
-    let st = app_state(empty_app_cfg(), None).await;
+    let st = app_state(empty_app_cfg()).await;
     let app = routes(false, st);
     let resp =
         app.clone().oneshot(post_json("/v1/wallets", &wallet_add_json("w_main"))).await.unwrap();
@@ -308,7 +305,7 @@ async fn wallets_post_succeeds() {
 
 #[tokio::test]
 async fn wallets_post_reserved_master_wallet_name() {
-    let st = app_state(empty_app_cfg(), None).await;
+    let st = app_state(empty_app_cfg()).await;
     let app = routes(false, st);
     let body = wallet_add_json("master_wallet");
     let resp = app.oneshot(post_json("/v1/wallets", &body)).await.unwrap();
@@ -319,7 +316,7 @@ async fn wallets_post_reserved_master_wallet_name() {
 
 #[tokio::test]
 async fn wallets_post_duplicate() {
-    let st = app_state(empty_app_cfg(), None).await;
+    let st = app_state(empty_app_cfg()).await;
     let app = routes(false, st);
     let body = wallet_add_json("w_dup");
     let resp = app.clone().oneshot(post_json("/v1/wallets", &body)).await.unwrap();
@@ -328,9 +325,21 @@ async fn wallets_post_duplicate() {
     assert_eq!(resp.status(), 400);
 }
 
+// --- DELETE /v1/wallets ---
+
 #[tokio::test]
-async fn wallets_delete_rejected_when_bound_then_succeeds_when_orphan() {
-    let mut cfg = (*empty_app_cfg()).clone();
+async fn wallets_delete_succeeds_when_orphan() {
+    let mut cfg = empty_app_cfg();
+    let (wn, wc) = sample_wallet("w_free");
+    cfg.wallets.insert(wn, wc);
+    let st = app_state(cfg).await;
+    let resp = routes(false, st).oneshot(delete("/v1/wallets/w_free")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+#[tokio::test]
+async fn wallets_delete_rejected_when_bound() {
+    let mut cfg = empty_app_cfg();
     let (nname, ncfg) = sample_node_adnl("w_del");
     cfg.nodes.insert(nname.clone(), ncfg);
     let (wname, wcfg) = sample_wallet("w_bound");
@@ -344,53 +353,46 @@ async fn wallets_delete_rejected_when_bound_then_succeeds_when_orphan() {
             status: BindingStatus::Idle,
         },
     );
-    let st = app_state(Arc::new(cfg), None).await;
-    let app = routes(false, st);
-
-    let resp = app.clone().oneshot(delete(&format!("/v1/wallets/{wname}"))).await.unwrap();
+    let st = app_state(cfg).await;
+    let resp = routes(false, st).oneshot(delete(&format!("/v1/wallets/{wname}"))).await.unwrap();
     assert_eq!(resp.status(), 400);
     let v = json(resp).await;
-    assert!(v["error"]["message"].as_str().unwrap().contains("binding"));
+    assert!(v["error"]["message"].as_str().unwrap().contains("referenced by binding"));
+}
 
-    cfg = (*empty_app_cfg()).clone();
-    let (wn, wc) = sample_wallet("w_free");
-    cfg.wallets.insert(wn, wc);
-    let st = app_state(Arc::new(cfg), None).await;
-    let app = routes(false, st);
-    let resp = app.oneshot(delete("/v1/wallets/w_free")).await.unwrap();
-    assert_eq!(resp.status(), 200);
+#[tokio::test]
+async fn wallets_delete_master_wallet_rejected() {
+    let st = app_state(empty_app_cfg()).await;
+    let resp = routes(false, st).oneshot(delete("/v1/wallets/master_wallet")).await.unwrap();
+    assert_eq!(resp.status(), 400);
+    let v = json(resp).await;
+    assert!(v["error"]["message"].as_str().unwrap().contains("master wallet"));
 }
 
 #[tokio::test]
 async fn wallets_delete_not_found() {
-    let st = app_state(empty_app_cfg(), None).await;
+    let st = app_state(empty_app_cfg()).await;
     let resp = routes(false, st).oneshot(delete("/v1/wallets/no_such_wallet")).await.unwrap();
     assert_eq!(resp.status(), 404);
 }
 
-// --- POST/DELETE /v1/pools (SNP) ---
+// --- POST /v1/pools (SNP) ---
 
 #[tokio::test]
-async fn pools_post_succeeds_missing_address_owner_rejected() {
-    let st = app_state(empty_app_cfg(), None).await;
-    let app = routes(false, st);
-
-    let resp = app
-        .clone()
-        .oneshot(post_json(
-            "/v1/pools",
-            &pool_add_json(
-                "pool_ok",
-                Some("-1:bd313e9e1114bbbe7af6f28ef59be0ff3f02ac795423f10397a70dc16396c4ea"),
-                None,
-            ),
-        ))
+async fn pools_post_succeeds() {
+    let st = app_state(empty_app_cfg()).await;
+    let resp = routes(false, st)
+        .oneshot(post_json("/v1/pools", &pool_add_json("pool_ok", Some(POOL_ADDR_A), None)))
         .await
         .unwrap();
     assert_eq!(resp.status(), 200);
+}
 
+#[tokio::test]
+async fn pools_post_missing_address_and_owner_rejected() {
+    let st = app_state(empty_app_cfg()).await;
     let body = serde_json::json!({ "name": "pool_bad", "address": null, "owner": null });
-    let resp = app.oneshot(post_json("/v1/pools", &body)).await.unwrap();
+    let resp = routes(false, st).oneshot(post_json("/v1/pools", &body)).await.unwrap();
     assert_eq!(resp.status(), 400);
     let v = json(resp).await;
     let msg = v["error"]["message"].as_str().unwrap();
@@ -398,23 +400,51 @@ async fn pools_post_succeeds_missing_address_owner_rejected() {
 }
 
 #[tokio::test]
+async fn pools_post_invalid_address_rejected() {
+    let st = app_state(empty_app_cfg()).await;
+    let body = pool_add_json("p_bad_addr", Some("not-a-valid-address"), None);
+    let resp = routes(false, st).oneshot(post_json("/v1/pools", &body)).await.unwrap();
+    assert_eq!(resp.status(), 400);
+    let v = json(resp).await;
+    assert!(v["error"]["message"].as_str().unwrap().contains("address"));
+}
+
+#[tokio::test]
+async fn pools_post_invalid_owner_rejected() {
+    let st = app_state(empty_app_cfg()).await;
+    let body = pool_add_json("p_bad_owner", None, Some("definitely-not-an-address"));
+    let resp = routes(false, st).oneshot(post_json("/v1/pools", &body)).await.unwrap();
+    assert_eq!(resp.status(), 400);
+    let v = json(resp).await;
+    assert!(v["error"]["message"].as_str().unwrap().contains("owner"));
+}
+
+#[tokio::test]
 async fn pools_post_duplicate() {
-    let st = app_state(empty_app_cfg(), None).await;
+    let st = app_state(empty_app_cfg()).await;
     let app = routes(false, st);
-    let body = pool_add_json(
-        "pool_dup",
-        Some("-1:bd313e9e1114bbbe7af6f28ef59be0ff3f02ac795423f10397a70dc16396c4ea"),
-        None,
-    );
+    let body = pool_add_json("pool_dup", Some(POOL_ADDR_A), None);
     let resp = app.clone().oneshot(post_json("/v1/pools", &body)).await.unwrap();
     assert_eq!(resp.status(), 200);
     let resp = app.oneshot(post_json("/v1/pools", &body)).await.unwrap();
     assert_eq!(resp.status(), 400);
 }
 
+// --- DELETE /v1/pools ---
+
 #[tokio::test]
-async fn pools_delete_rejected_when_bound_then_succeeds_when_orphan() {
-    let mut cfg = (*empty_app_cfg()).clone();
+async fn pools_delete_succeeds_when_orphan() {
+    let mut cfg = empty_app_cfg();
+    let (pn, pc) = sample_snp_pool("p_free");
+    cfg.pools.insert(pn, pc);
+    let st = app_state(cfg).await;
+    let resp = routes(false, st).oneshot(delete("/v1/pools/p_free")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+#[tokio::test]
+async fn pools_delete_rejected_when_bound() {
+    let mut cfg = empty_app_cfg();
     let (nname, ncfg) = sample_node_adnl("p_del");
     cfg.nodes.insert(nname.clone(), ncfg);
     let (wname, wcfg) = sample_wallet("pw");
@@ -430,41 +460,79 @@ async fn pools_delete_rejected_when_bound_then_succeeds_when_orphan() {
             status: BindingStatus::Idle,
         },
     );
-    let st = app_state(Arc::new(cfg), None).await;
-    let app = routes(false, st);
-
-    let resp = app.clone().oneshot(delete(&format!("/v1/pools/{pname}"))).await.unwrap();
+    let st = app_state(cfg).await;
+    let resp = routes(false, st).oneshot(delete(&format!("/v1/pools/{pname}"))).await.unwrap();
     assert_eq!(resp.status(), 400);
-
-    let mut cfg = (*empty_app_cfg()).clone();
-    let (pn, pc) = sample_snp_pool("p_free");
-    cfg.pools.insert(pn, pc);
-    let st = app_state(Arc::new(cfg), None).await;
-    let app = routes(false, st);
-    let resp = app.oneshot(delete("/v1/pools/p_free")).await.unwrap();
-    assert_eq!(resp.status(), 200);
 }
 
 #[tokio::test]
 async fn pools_delete_not_found() {
-    let st = app_state(empty_app_cfg(), None).await;
+    let st = app_state(empty_app_cfg()).await;
     let resp = routes(false, st).oneshot(delete("/v1/pools/no_such_pool")).await.unwrap();
     assert_eq!(resp.status(), 404);
 }
 
-// --- POST/DELETE /v1/bindings ---
+// --- POST /v1/bindings ---
 
 #[tokio::test]
-async fn bindings_post_succeeds_duplicate_rejected() {
-    let mut cfg = (*empty_app_cfg()).clone();
+async fn bindings_post_succeeds() {
+    let mut cfg = empty_app_cfg();
     let (nname, ncfg) = sample_node_adnl("bind");
     cfg.nodes.insert(nname.clone(), ncfg);
     let (bw, bwc) = sample_wallet("bind_w");
     cfg.wallets.insert(bw.clone(), bwc);
 
-    let st = app_state(Arc::new(cfg), None).await;
+    let st = app_state(cfg).await;
     let app = routes(false, st);
+    let resp = app
+        .clone()
+        .oneshot(post_json("/v1/bindings", &binding_add_json(&nname, &bw, None)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+}
 
+#[tokio::test]
+async fn bindings_post_succeeds_with_pool() {
+    let mut cfg = empty_app_cfg();
+    let (nname, ncfg) = sample_node_adnl("bind_p");
+    cfg.nodes.insert(nname.clone(), ncfg);
+    let (wn, wc) = sample_wallet("bind_p_w");
+    cfg.wallets.insert(wn.clone(), wc);
+    let (pn, pc) = sample_snp_pool("bind_p_pool");
+    cfg.pools.insert(pn.clone(), pc);
+
+    let st = app_state(cfg).await;
+    let app = routes(false, st);
+    let resp = app
+        .clone()
+        .oneshot(post_json("/v1/bindings", &binding_add_json(&nname, &wn, Some(&pn))))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    // Verify the pool reference round-trips via GET /v1/bindings.
+    let resp = app.oneshot(get("/v1/bindings")).await.unwrap();
+    let v = json(resp).await;
+    let entry = v["result"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|b| b["node"].as_str() == Some(&nname))
+        .expect("binding should be listed");
+    assert_eq!(entry["pool"].as_str(), Some(pn.as_str()));
+}
+
+#[tokio::test]
+async fn bindings_post_duplicate_rejected() {
+    let mut cfg = empty_app_cfg();
+    let (nname, ncfg) = sample_node_adnl("dup");
+    cfg.nodes.insert(nname.clone(), ncfg);
+    let (bw, bwc) = sample_wallet("dup_w");
+    cfg.wallets.insert(bw.clone(), bwc);
+
+    let st = app_state(cfg).await;
+    let app = routes(false, st);
     let body = binding_add_json(&nname, &bw, None);
     let resp = app.clone().oneshot(post_json("/v1/bindings", &body)).await.unwrap();
     assert_eq!(resp.status(), 200);
@@ -477,7 +545,7 @@ async fn bindings_post_succeeds_duplicate_rejected() {
 
 #[tokio::test]
 async fn bindings_post_missing_refs() {
-    let mut cfg = (*empty_app_cfg()).clone();
+    let mut cfg = empty_app_cfg();
     let (nname, ncfg) = sample_node_adnl("mr");
     cfg.nodes.insert(nname.clone(), ncfg);
     let (mwn, mwc) = sample_wallet("mr_w");
@@ -485,7 +553,7 @@ async fn bindings_post_missing_refs() {
     let (pname, pcfg) = sample_snp_pool("mr_p");
     cfg.pools.insert(pname.clone(), pcfg);
 
-    let st = app_state(Arc::new(cfg), None).await;
+    let st = app_state(cfg).await;
     let app = routes(false, st);
 
     let resp = app
@@ -495,7 +563,7 @@ async fn bindings_post_missing_refs() {
         .unwrap();
     assert_eq!(resp.status(), 400);
     let v = json(resp).await;
-    assert!(v["error"]["message"].as_str().unwrap().contains("node"));
+    assert!(v["error"]["message"].as_str().unwrap().contains("node 'no_such_node' not found"));
 
     let resp = app
         .clone()
@@ -504,7 +572,7 @@ async fn bindings_post_missing_refs() {
         .unwrap();
     assert_eq!(resp.status(), 400);
     let v = json(resp).await;
-    assert!(v["error"]["message"].as_str().unwrap().contains("wallet"));
+    assert!(v["error"]["message"].as_str().unwrap().contains("wallet 'no_wallet' not found"));
 
     let resp = app
         .oneshot(post_json("/v1/bindings", &binding_add_json(&nname, &mwn, Some("no_pool"))))
@@ -512,50 +580,82 @@ async fn bindings_post_missing_refs() {
         .unwrap();
     assert_eq!(resp.status(), 400);
     let v = json(resp).await;
-    assert!(v["error"]["message"].as_str().unwrap().contains("pool"));
+    assert!(v["error"]["message"].as_str().unwrap().contains("pool 'no_pool' not found"));
 }
 
 #[tokio::test]
-async fn bindings_delete_succeeds_when_idle_non_idle_rejected() {
-    let mut cfg = (*empty_app_cfg()).clone();
-    let (nname, ncfg) = sample_node_adnl("idle_rm");
-    cfg.nodes.insert(nname.clone(), ncfg.clone());
-    let (idle_wn, idle_wc) = sample_wallet("idle_w");
-    cfg.wallets.insert(idle_wn.clone(), idle_wc);
+async fn bindings_post_pool_already_bound() {
+    let mut cfg = empty_app_cfg();
+    let (n1, n1c) = sample_node_adnl("ab1");
+    let (n2, n2c) = sample_node_adnl("ab2");
+    cfg.nodes.insert(n1.clone(), n1c);
+    cfg.nodes.insert(n2.clone(), n2c);
+    let (w, wc) = sample_wallet("ab_w");
+    cfg.wallets.insert(w.clone(), wc);
+    let (p, pc) = sample_snp_pool("ab_p");
+    cfg.pools.insert(p.clone(), pc);
     cfg.bindings.insert(
-        nname.clone(),
-        NodeBinding { wallet: idle_wn, pool: None, enable: false, status: BindingStatus::Idle },
-    );
-
-    let st = app_state(Arc::new(cfg), None).await;
-    let app = routes(false, st);
-    let resp = app.oneshot(delete(&format!("/v1/bindings/{nname}"))).await.unwrap();
-    assert_eq!(resp.status(), 200);
-
-    let mut cfg = (*empty_app_cfg()).clone();
-    cfg.nodes.insert(nname.clone(), ncfg);
-    let (busy_wn, busy_wc) = sample_wallet("busy_w");
-    cfg.wallets.insert(busy_wn.clone(), busy_wc);
-    cfg.bindings.insert(
-        nname.clone(),
+        n1.clone(),
         NodeBinding {
-            wallet: busy_wn,
-            pool: None,
+            wallet: w.clone(),
+            pool: Some(p.clone()),
             enable: false,
-            status: BindingStatus::Validating,
+            status: BindingStatus::Idle,
         },
     );
-    let st = app_state(Arc::new(cfg), None).await;
-    let app = routes(false, st);
-    let resp = app.oneshot(delete(&format!("/v1/bindings/{nname}"))).await.unwrap();
+
+    let st = app_state(cfg).await;
+    let resp = routes(false, st)
+        .oneshot(post_json("/v1/bindings", &binding_add_json(&n2, &w, Some(&p))))
+        .await
+        .unwrap();
     assert_eq!(resp.status(), 400);
     let v = json(resp).await;
-    assert!(v["error"]["message"].as_str().unwrap().contains("idle"));
+    let msg = v["error"]["message"].as_str().unwrap();
+    assert!(msg.contains("already bound"), "unexpected error message: {msg}");
+}
+
+// --- DELETE /v1/bindings ---
+
+#[tokio::test]
+async fn bindings_delete_succeeds_when_idle() {
+    let mut cfg = empty_app_cfg();
+    let (nname, ncfg) = sample_node_adnl("idle_rm");
+    cfg.nodes.insert(nname.clone(), ncfg);
+    let (wn, wc) = sample_wallet("idle_w");
+    cfg.wallets.insert(wn.clone(), wc);
+    cfg.bindings.insert(
+        nname.clone(),
+        NodeBinding { wallet: wn, pool: None, enable: false, status: BindingStatus::Idle },
+    );
+
+    let st = app_state(cfg).await;
+    let resp = routes(false, st).oneshot(delete(&format!("/v1/bindings/{nname}"))).await.unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+#[tokio::test]
+async fn bindings_delete_rejected_when_non_idle() {
+    let mut cfg = empty_app_cfg();
+    let (nname, ncfg) = sample_node_adnl("busy_rm");
+    cfg.nodes.insert(nname.clone(), ncfg);
+    let (wn, wc) = sample_wallet("busy_w");
+    cfg.wallets.insert(wn.clone(), wc);
+    cfg.bindings.insert(
+        nname.clone(),
+        NodeBinding { wallet: wn, pool: None, enable: false, status: BindingStatus::Validating },
+    );
+
+    let st = app_state(cfg).await;
+    let resp = routes(false, st).oneshot(delete(&format!("/v1/bindings/{nname}"))).await.unwrap();
+    assert_eq!(resp.status(), 400);
+    let v = json(resp).await;
+    assert!(v["error"]["message"].as_str().unwrap().contains("must be 'idle'"));
 }
 
 #[tokio::test]
 async fn bindings_delete_not_found() {
-    let st = app_state(empty_app_cfg(), None).await;
+    let st = app_state(empty_app_cfg()).await;
     let resp = routes(false, st).oneshot(delete("/v1/bindings/no_such_node")).await.unwrap();
     assert_eq!(resp.status(), 404);
 }
@@ -566,7 +666,7 @@ async fn bindings_delete_not_found() {
 async fn mutation_persists_config_to_disk() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("cfg.json");
-    let st = app_state(empty_app_cfg(), Some(path.clone())).await;
+    let st = app_state_with_path(empty_app_cfg(), path.clone()).await;
     let app = routes(false, st);
 
     let resp = app

--- a/src/node-control/service/src/http/entity_crud_handlers_tests.rs
+++ b/src/node-control/service/src/http/entity_crud_handlers_tests.rs
@@ -26,7 +26,15 @@ use common::{
     task_cancellation::CancellationCtx,
 };
 use http_body_util::BodyExt;
-use std::{collections::HashMap, path::PathBuf, sync::Arc};
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::{SystemTime, UNIX_EPOCH},
+};
 use tower::ServiceExt;
 
 struct Noop;
@@ -102,14 +110,27 @@ fn sample_snp_pool(name: &str) -> (String, PoolConfig) {
     )
 }
 
+fn unique_test_config_path() -> PathBuf {
+    static NEXT_ID: AtomicU64 = AtomicU64::new(0);
+    let unique_id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+    std::env::temp_dir().join(format!(
+        "node-control-entity-crud-tests-{}-{}-{}.json",
+        std::process::id(),
+        nanos,
+        unique_id
+    ))
+}
+
+/// Builds [`AppState`] for router tests. Uses a unique temp config path so parallel tests never
+/// share `save_to_file` output (the default `from_app_config` `"noop"` path is unsuitable under
+/// `cargo test -- --test-threads=N`).
 async fn app_state(cfg: Arc<AppConfig>, config_path: Option<PathBuf>) -> AppState {
-    let rt: Arc<RuntimeConfigStore> = match config_path {
-        Some(p) => Arc::new(RuntimeConfigStore::from_app_config_with_path(
-            cfg,
-            p.to_string_lossy().into_owned(),
-        )),
-        None => Arc::new(RuntimeConfigStore::from_app_config(cfg)),
-    };
+    let path = config_path.unwrap_or_else(unique_test_config_path);
+    let rt = Arc::new(RuntimeConfigStore::from_app_config_with_path(
+        cfg,
+        path.to_string_lossy().into_owned(),
+    ));
     let jwt_auth = Arc::new(JwtAuth::new(None, Some(TEST_JWT_SECRET)).await.unwrap());
     AppState {
         store: Arc::new(SnapshotStore::new()),

--- a/src/node-control/service/src/http/entity_crud_handlers_tests.rs
+++ b/src/node-control/service/src/http/entity_crud_handlers_tests.rs
@@ -1,0 +1,570 @@
+/*
+ * Copyright (C) 2025-2026 RSquad Blockchain Lab.
+ *
+ * Licensed under the GNU General Public License v3.0.
+ * See the LICENSE file in the root of this repository.
+ *
+ * This software is provided "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ */
+//! REST mutation tests for `/v1/nodes`, `/v1/wallets`, `/v1/pools`, `/v1/bindings`.
+use crate::{
+    auth::{jwt::JwtAuth, user_store::UserStore},
+    http::http_server_task::*,
+    runtime_config::{RuntimeConfig, RuntimeConfigStore},
+    task::task_manager::{ServiceTask, TaskController},
+};
+use adnl::common::Timeouts;
+use axum::body::Body;
+use base64::Engine;
+use common::{
+    TonWalletVersion,
+    app_config::{
+        AdnlConfig, AppConfig, BindingStatus, HttpConfig, KeyConfig, NodeBinding, PoolConfig,
+        TimeoutVariant, WalletConfig,
+    },
+    snapshot::SnapshotStore,
+    task_cancellation::CancellationCtx,
+};
+use http_body_util::BodyExt;
+use std::{collections::HashMap, path::PathBuf, sync::Arc};
+use tower::ServiceExt;
+
+struct Noop;
+
+#[async_trait::async_trait]
+impl ServiceTask for Noop {
+    async fn run(&self, ctx: CancellationCtx, _: Arc<AppConfig>) -> anyhow::Result<()> {
+        let mut c = ctx.subscribe();
+        let _ = c.changed().await;
+        Ok(())
+    }
+}
+
+const TEST_JWT_SECRET: &str = "KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKio="; // [42u8; 32]
+
+/// ADNL server key type id (must match `config_handlers::ADNL_PUBKEY_TYPE_ID`).
+const ADNL_PUBKEY_TYPE_ID: i32 = 1209251014;
+
+fn empty_app_cfg() -> Arc<AppConfig> {
+    Arc::new(AppConfig {
+        nodes: HashMap::new(),
+        wallets: HashMap::new(),
+        pools: HashMap::new(),
+        bindings: HashMap::new(),
+        ton_http_api: Default::default(),
+        http: HttpConfig { auth: None, ..Default::default() },
+        elections: Some(Default::default()),
+        voting: None,
+        master_wallet: None,
+        tick_interval: 30,
+        log: Some(Default::default()),
+    })
+}
+
+fn valid_control_server_pubkey_b64() -> String {
+    base64::engine::general_purpose::STANDARD.encode([11u8; 32])
+}
+
+fn sample_node_adnl(name_suffix: &str) -> (String, AdnlConfig) {
+    let name = format!("pre_{name_suffix}");
+    let cfg = AdnlConfig {
+        server_address: "127.0.0.1:3031".into(),
+        server_key: KeyConfig::PublicKey { type_id: ADNL_PUBKEY_TYPE_ID, pub_key: vec![5u8; 32] },
+        client_key: KeyConfig::VaultKey { name: "client_key".into() },
+        timeouts: TimeoutVariant::Single(Timeouts::DEFAULT_TIMEOUT.as_secs()),
+    };
+    (name, cfg)
+}
+
+fn sample_wallet(name: &str) -> (String, WalletConfig) {
+    (
+        name.into(),
+        WalletConfig {
+            key: KeyConfig::VaultKey { name: format!("{name}_sec") },
+            version: TonWalletVersion::V4R2,
+            subwallet_id: 0,
+            workchain: -1,
+        },
+    )
+}
+
+fn sample_snp_pool(name: &str) -> (String, PoolConfig) {
+    (
+        name.into(),
+        PoolConfig::SNP {
+            address: Some(
+                "-1:bd313e9e1114bbbe7af6f28ef59be0ff3f02ac795423f10397a70dc16396c4ea".into(),
+            ),
+            owner: Some(
+                "0:c5770dc489bef32419959c174b787ab95ff9109e0e43239c18059509819697fb".into(),
+            ),
+        },
+    )
+}
+
+async fn app_state(cfg: Arc<AppConfig>, config_path: Option<PathBuf>) -> AppState {
+    let rt: Arc<RuntimeConfigStore> = match config_path {
+        Some(p) => Arc::new(RuntimeConfigStore::from_app_config_with_path(
+            cfg,
+            p.to_string_lossy().into_owned(),
+        )),
+        None => Arc::new(RuntimeConfigStore::from_app_config(cfg)),
+    };
+    let jwt_auth = Arc::new(JwtAuth::new(None, Some(TEST_JWT_SECRET)).await.unwrap());
+    AppState {
+        store: Arc::new(SnapshotStore::new()),
+        runtime_cfg: rt.clone(),
+        elections_task: Arc::new(TaskController::new("elections", Noop, rt.clone())),
+        jwt_auth,
+        user_store: Arc::new(UserStore::new(rt as Arc<dyn RuntimeConfig>)),
+        login_rate_limiter: Arc::new(tokio::sync::Mutex::new(Default::default())),
+        config_changed: Arc::new(tokio::sync::Notify::new()),
+    }
+}
+
+async fn json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+fn get(uri: &str) -> axum::http::Request<Body> {
+    axum::http::Request::builder().uri(uri).body(Body::empty()).unwrap()
+}
+
+fn post_json(uri: &str, body: &impl serde::Serialize) -> axum::http::Request<Body> {
+    axum::http::Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_string(body).unwrap()))
+        .unwrap()
+}
+
+fn delete(uri: &str) -> axum::http::Request<Body> {
+    axum::http::Request::builder().method("DELETE").uri(uri).body(Body::empty()).unwrap()
+}
+
+fn node_add_json(name: &str) -> serde_json::Value {
+    serde_json::json!({
+        "name": name,
+        "control_server_endpoint": "127.0.0.1:3033",
+        "control_server_pubkey": valid_control_server_pubkey_b64(),
+        "control_client_secret": "node_client_sec",
+    })
+}
+
+fn wallet_add_json(name: &str) -> serde_json::Value {
+    serde_json::json!({
+        "name": name,
+        "secret": "wallet_sec",
+        "version": "V4R2",
+        "subwallet_id": 0,
+        "workchain": -1,
+    })
+}
+
+fn pool_add_json(name: &str, address: Option<&str>, owner: Option<&str>) -> serde_json::Value {
+    serde_json::json!({
+        "name": name,
+        "address": address,
+        "owner": owner,
+    })
+}
+
+fn binding_add_json(node: &str, wallet: &str, pool: Option<&str>) -> serde_json::Value {
+    serde_json::json!({
+        "node": node,
+        "wallet": wallet,
+        "pool": pool,
+    })
+}
+
+// --- POST /v1/nodes ---
+
+#[tokio::test]
+async fn nodes_post_happy_path() {
+    let st = app_state(empty_app_cfg(), None).await;
+    let app = routes(false, st);
+    let resp = app.clone().oneshot(post_json("/v1/nodes", &node_add_json("node_a"))).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let v = json(resp).await;
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["result"]["name"], "node_a");
+
+    let resp = app.oneshot(get("/v1/nodes")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let v = json(resp).await;
+    let names: Vec<String> = v["result"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|x| x["name"].as_str().map(String::from))
+        .collect();
+    assert!(names.contains(&"node_a".into()));
+}
+
+#[tokio::test]
+async fn nodes_post_duplicate() {
+    let st = app_state(empty_app_cfg(), None).await;
+    let app = routes(false, st);
+    let body = node_add_json("dup_node");
+    let resp = app.clone().oneshot(post_json("/v1/nodes", &body)).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let resp = app.oneshot(post_json("/v1/nodes", &body)).await.unwrap();
+    assert_eq!(resp.status(), 400);
+    let v = json(resp).await;
+    assert!(v["error"]["message"].as_str().unwrap().contains("already exists"));
+}
+
+#[tokio::test]
+async fn nodes_post_invalid_pubkey_base64() {
+    let st = app_state(empty_app_cfg(), None).await;
+    let app = routes(false, st);
+    let body = serde_json::json!({
+        "name": "n_bad_pk",
+        "control_server_endpoint": "127.0.0.1:1",
+        "control_server_pubkey": "not-valid-base64!!!",
+        "control_client_secret": "sec",
+    });
+    let resp = app.oneshot(post_json("/v1/nodes", &body)).await.unwrap();
+    assert_eq!(resp.status(), 400);
+    let v = json(resp).await;
+    assert!(v["error"]["message"].as_str().unwrap().contains("base64"));
+}
+
+#[tokio::test]
+async fn nodes_delete_happy_and_not_found() {
+    let st = app_state(empty_app_cfg(), None).await;
+    let app = routes(false, st);
+    let body = node_add_json("to_rm");
+    let resp = app.clone().oneshot(post_json("/v1/nodes", &body)).await.unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let resp = app.clone().oneshot(delete("/v1/nodes/to_rm")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let resp = app.oneshot(delete("/v1/nodes/to_rm")).await.unwrap();
+    assert_eq!(resp.status(), 404);
+}
+
+#[tokio::test]
+async fn nodes_delete_referenced_by_binding() {
+    let mut cfg = (*empty_app_cfg()).clone();
+    let (nname, ncfg) = sample_node_adnl("bound");
+    cfg.nodes.insert(nname.clone(), ncfg);
+    let (wname, wcfg) = sample_wallet("bw");
+    cfg.wallets.insert(wname.clone(), wcfg);
+    cfg.bindings.insert(
+        nname.clone(),
+        NodeBinding { wallet: wname, pool: None, enable: false, status: BindingStatus::Idle },
+    );
+    let st = app_state(Arc::new(cfg), None).await;
+    let app = routes(false, st);
+    let resp = app.oneshot(delete(&format!("/v1/nodes/{nname}"))).await.unwrap();
+    assert_eq!(resp.status(), 400);
+    let v = json(resp).await;
+    assert!(v["error"]["message"].as_str().unwrap().contains("binding"));
+}
+
+// --- POST/DELETE /v1/wallets ---
+
+#[tokio::test]
+async fn wallets_post_happy_path() {
+    let st = app_state(empty_app_cfg(), None).await;
+    let app = routes(false, st);
+    let resp =
+        app.clone().oneshot(post_json("/v1/wallets", &wallet_add_json("w_main"))).await.unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let resp = app.oneshot(get("/v1/wallets")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let v = json(resp).await;
+    let names: Vec<String> = v["result"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|x| x["name"].as_str().map(String::from))
+        .collect();
+    assert!(names.contains(&"w_main".into()));
+}
+
+#[tokio::test]
+async fn wallets_post_reserved_master_wallet_name() {
+    let st = app_state(empty_app_cfg(), None).await;
+    let app = routes(false, st);
+    let body = wallet_add_json("master_wallet");
+    let resp = app.oneshot(post_json("/v1/wallets", &body)).await.unwrap();
+    assert_eq!(resp.status(), 400);
+    let v = json(resp).await;
+    assert!(v["error"]["message"].as_str().unwrap().contains("reserved"));
+}
+
+#[tokio::test]
+async fn wallets_post_duplicate() {
+    let st = app_state(empty_app_cfg(), None).await;
+    let app = routes(false, st);
+    let body = wallet_add_json("w_dup");
+    let resp = app.clone().oneshot(post_json("/v1/wallets", &body)).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let resp = app.oneshot(post_json("/v1/wallets", &body)).await.unwrap();
+    assert_eq!(resp.status(), 400);
+}
+
+#[tokio::test]
+async fn wallets_delete_happy_and_referenced_by_binding() {
+    let mut cfg = (*empty_app_cfg()).clone();
+    let (nname, ncfg) = sample_node_adnl("w_del");
+    cfg.nodes.insert(nname.clone(), ncfg);
+    let (wname, wcfg) = sample_wallet("w_bound");
+    cfg.wallets.insert(wname.clone(), wcfg);
+    cfg.bindings.insert(
+        nname,
+        NodeBinding {
+            wallet: wname.clone(),
+            pool: None,
+            enable: false,
+            status: BindingStatus::Idle,
+        },
+    );
+    let st = app_state(Arc::new(cfg), None).await;
+    let app = routes(false, st);
+
+    let resp = app.clone().oneshot(delete(&format!("/v1/wallets/{wname}"))).await.unwrap();
+    assert_eq!(resp.status(), 400);
+    let v = json(resp).await;
+    assert!(v["error"]["message"].as_str().unwrap().contains("binding"));
+
+    cfg = (*empty_app_cfg()).clone();
+    let (wn, wc) = sample_wallet("w_free");
+    cfg.wallets.insert(wn, wc);
+    let st = app_state(Arc::new(cfg), None).await;
+    let app = routes(false, st);
+    let resp = app.oneshot(delete("/v1/wallets/w_free")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+#[tokio::test]
+async fn wallets_delete_not_found() {
+    let st = app_state(empty_app_cfg(), None).await;
+    let resp = routes(false, st).oneshot(delete("/v1/wallets/no_such_wallet")).await.unwrap();
+    assert_eq!(resp.status(), 404);
+}
+
+// --- POST/DELETE /v1/pools (SNP) ---
+
+#[tokio::test]
+async fn pools_post_happy_and_missing_address_owner() {
+    let st = app_state(empty_app_cfg(), None).await;
+    let app = routes(false, st);
+
+    let resp = app
+        .clone()
+        .oneshot(post_json(
+            "/v1/pools",
+            &pool_add_json(
+                "pool_ok",
+                Some("-1:bd313e9e1114bbbe7af6f28ef59be0ff3f02ac795423f10397a70dc16396c4ea"),
+                None,
+            ),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let body = serde_json::json!({ "name": "pool_bad", "address": null, "owner": null });
+    let resp = app.oneshot(post_json("/v1/pools", &body)).await.unwrap();
+    assert_eq!(resp.status(), 400);
+    let v = json(resp).await;
+    let msg = v["error"]["message"].as_str().unwrap();
+    assert!(msg.contains("address") && msg.contains("owner"), "unexpected error message: {msg}");
+}
+
+#[tokio::test]
+async fn pools_post_duplicate() {
+    let st = app_state(empty_app_cfg(), None).await;
+    let app = routes(false, st);
+    let body = pool_add_json(
+        "pool_dup",
+        Some("-1:bd313e9e1114bbbe7af6f28ef59be0ff3f02ac795423f10397a70dc16396c4ea"),
+        None,
+    );
+    let resp = app.clone().oneshot(post_json("/v1/pools", &body)).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let resp = app.oneshot(post_json("/v1/pools", &body)).await.unwrap();
+    assert_eq!(resp.status(), 400);
+}
+
+#[tokio::test]
+async fn pools_delete_happy_and_referenced_by_binding() {
+    let mut cfg = (*empty_app_cfg()).clone();
+    let (nname, ncfg) = sample_node_adnl("p_del");
+    cfg.nodes.insert(nname.clone(), ncfg);
+    let (wname, wcfg) = sample_wallet("pw");
+    cfg.wallets.insert(wname.clone(), wcfg);
+    let (pname, pcfg) = sample_snp_pool("p_bound");
+    cfg.pools.insert(pname.clone(), pcfg);
+    cfg.bindings.insert(
+        nname,
+        NodeBinding {
+            wallet: wname,
+            pool: Some(pname.clone()),
+            enable: false,
+            status: BindingStatus::Idle,
+        },
+    );
+    let st = app_state(Arc::new(cfg), None).await;
+    let app = routes(false, st);
+
+    let resp = app.clone().oneshot(delete(&format!("/v1/pools/{pname}"))).await.unwrap();
+    assert_eq!(resp.status(), 400);
+
+    let mut cfg = (*empty_app_cfg()).clone();
+    let (pn, pc) = sample_snp_pool("p_free");
+    cfg.pools.insert(pn, pc);
+    let st = app_state(Arc::new(cfg), None).await;
+    let app = routes(false, st);
+    let resp = app.oneshot(delete("/v1/pools/p_free")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+#[tokio::test]
+async fn pools_delete_not_found() {
+    let st = app_state(empty_app_cfg(), None).await;
+    let resp = routes(false, st).oneshot(delete("/v1/pools/no_such_pool")).await.unwrap();
+    assert_eq!(resp.status(), 404);
+}
+
+// --- POST/DELETE /v1/bindings ---
+
+#[tokio::test]
+async fn bindings_post_happy_path_and_duplicate() {
+    let mut cfg = (*empty_app_cfg()).clone();
+    let (nname, ncfg) = sample_node_adnl("bind");
+    cfg.nodes.insert(nname.clone(), ncfg);
+    let (bw, bwc) = sample_wallet("bind_w");
+    cfg.wallets.insert(bw.clone(), bwc);
+
+    let st = app_state(Arc::new(cfg), None).await;
+    let app = routes(false, st);
+
+    let body = binding_add_json(&nname, &bw, None);
+    let resp = app.clone().oneshot(post_json("/v1/bindings", &body)).await.unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let resp = app.oneshot(post_json("/v1/bindings", &body)).await.unwrap();
+    assert_eq!(resp.status(), 400);
+    let v = json(resp).await;
+    assert!(v["error"]["message"].as_str().unwrap().contains("already exists"));
+}
+
+#[tokio::test]
+async fn bindings_post_missing_refs() {
+    let mut cfg = (*empty_app_cfg()).clone();
+    let (nname, ncfg) = sample_node_adnl("mr");
+    cfg.nodes.insert(nname.clone(), ncfg);
+    let (mwn, mwc) = sample_wallet("mr_w");
+    cfg.wallets.insert(mwn.clone(), mwc);
+    let (pname, pcfg) = sample_snp_pool("mr_p");
+    cfg.pools.insert(pname.clone(), pcfg);
+
+    let st = app_state(Arc::new(cfg), None).await;
+    let app = routes(false, st);
+
+    let resp = app
+        .clone()
+        .oneshot(post_json("/v1/bindings", &binding_add_json("no_such_node", "mr_w", None)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    let v = json(resp).await;
+    assert!(v["error"]["message"].as_str().unwrap().contains("node"));
+
+    let resp = app
+        .clone()
+        .oneshot(post_json("/v1/bindings", &binding_add_json(&nname, "no_wallet", None)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    let v = json(resp).await;
+    assert!(v["error"]["message"].as_str().unwrap().contains("wallet"));
+
+    let resp = app
+        .oneshot(post_json("/v1/bindings", &binding_add_json(&nname, &mwn, Some("no_pool"))))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    let v = json(resp).await;
+    assert!(v["error"]["message"].as_str().unwrap().contains("pool"));
+}
+
+#[tokio::test]
+async fn bindings_delete_happy_and_non_idle() {
+    let mut cfg = (*empty_app_cfg()).clone();
+    let (nname, ncfg) = sample_node_adnl("idle_rm");
+    cfg.nodes.insert(nname.clone(), ncfg.clone());
+    let (idle_wn, idle_wc) = sample_wallet("idle_w");
+    cfg.wallets.insert(idle_wn.clone(), idle_wc);
+    cfg.bindings.insert(
+        nname.clone(),
+        NodeBinding { wallet: idle_wn, pool: None, enable: false, status: BindingStatus::Idle },
+    );
+
+    let st = app_state(Arc::new(cfg), None).await;
+    let app = routes(false, st);
+    let resp = app.oneshot(delete(&format!("/v1/bindings/{nname}"))).await.unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let mut cfg = (*empty_app_cfg()).clone();
+    cfg.nodes.insert(nname.clone(), ncfg);
+    let (busy_wn, busy_wc) = sample_wallet("busy_w");
+    cfg.wallets.insert(busy_wn.clone(), busy_wc);
+    cfg.bindings.insert(
+        nname.clone(),
+        NodeBinding {
+            wallet: busy_wn,
+            pool: None,
+            enable: false,
+            status: BindingStatus::Validating,
+        },
+    );
+    let st = app_state(Arc::new(cfg), None).await;
+    let app = routes(false, st);
+    let resp = app.oneshot(delete(&format!("/v1/bindings/{nname}"))).await.unwrap();
+    assert_eq!(resp.status(), 400);
+    let v = json(resp).await;
+    assert!(v["error"]["message"].as_str().unwrap().contains("idle"));
+}
+
+#[tokio::test]
+async fn bindings_delete_not_found() {
+    let st = app_state(empty_app_cfg(), None).await;
+    let resp = routes(false, st).oneshot(delete("/v1/bindings/no_such_node")).await.unwrap();
+    assert_eq!(resp.status(), 404);
+}
+
+// --- Config persisted to disk ---
+
+#[tokio::test]
+async fn mutation_persists_config_to_disk() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("cfg.json");
+    let st = app_state(empty_app_cfg(), Some(path.clone())).await;
+    let app = routes(false, st);
+
+    let resp = app
+        .clone()
+        .oneshot(post_json("/v1/nodes", &node_add_json("persisted_node")))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let raw = std::fs::read_to_string(&path).expect("config file written by save_to_file");
+    let cfg: AppConfig = serde_json::from_str(&raw).unwrap();
+    assert!(cfg.nodes.contains_key("persisted_node"));
+
+    let resp = app.oneshot(delete("/v1/nodes/persisted_node")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let raw = std::fs::read_to_string(&path).unwrap();
+    let cfg: AppConfig = serde_json::from_str(&raw).unwrap();
+    assert!(!cfg.nodes.contains_key("persisted_node"));
+}

--- a/src/node-control/service/src/http/entity_crud_handlers_tests.rs
+++ b/src/node-control/service/src/http/entity_crud_handlers_tests.rs
@@ -9,7 +9,7 @@
 //! REST mutation tests for `/v1/nodes`, `/v1/wallets`, `/v1/pools`, `/v1/bindings`.
 use crate::{
     auth::{jwt::JwtAuth, user_store::UserStore},
-    http::http_server_task::*,
+    http::{config_handlers::ADNL_PUBKEY_TYPE_ID, http_server_task::*},
     runtime_config::{RuntimeConfig, RuntimeConfigStore},
     task::task_manager::{ServiceTask, TaskController},
 };
@@ -49,9 +49,6 @@ impl ServiceTask for Noop {
 }
 
 const TEST_JWT_SECRET: &str = "KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKio="; // [42u8; 32]
-
-/// ADNL server key type id (must match `config_handlers::ADNL_PUBKEY_TYPE_ID`).
-const ADNL_PUBKEY_TYPE_ID: i32 = 1209251014;
 
 fn empty_app_cfg() -> Arc<AppConfig> {
     Arc::new(AppConfig {
@@ -203,7 +200,7 @@ fn binding_add_json(node: &str, wallet: &str, pool: Option<&str>) -> serde_json:
 // --- POST /v1/nodes ---
 
 #[tokio::test]
-async fn nodes_post_happy_path() {
+async fn nodes_post_succeeds() {
     let st = app_state(empty_app_cfg(), None).await;
     let app = routes(false, st);
     let resp = app.clone().oneshot(post_json("/v1/nodes", &node_add_json("node_a"))).await.unwrap();
@@ -254,7 +251,7 @@ async fn nodes_post_invalid_pubkey_base64() {
 }
 
 #[tokio::test]
-async fn nodes_delete_happy_and_not_found() {
+async fn nodes_delete_succeeds_then_not_found() {
     let st = app_state(empty_app_cfg(), None).await;
     let app = routes(false, st);
     let body = node_add_json("to_rm");
@@ -290,7 +287,7 @@ async fn nodes_delete_referenced_by_binding() {
 // --- POST/DELETE /v1/wallets ---
 
 #[tokio::test]
-async fn wallets_post_happy_path() {
+async fn wallets_post_succeeds() {
     let st = app_state(empty_app_cfg(), None).await;
     let app = routes(false, st);
     let resp =
@@ -332,7 +329,7 @@ async fn wallets_post_duplicate() {
 }
 
 #[tokio::test]
-async fn wallets_delete_happy_and_referenced_by_binding() {
+async fn wallets_delete_rejected_when_bound_then_succeeds_when_orphan() {
     let mut cfg = (*empty_app_cfg()).clone();
     let (nname, ncfg) = sample_node_adnl("w_del");
     cfg.nodes.insert(nname.clone(), ncfg);
@@ -374,7 +371,7 @@ async fn wallets_delete_not_found() {
 // --- POST/DELETE /v1/pools (SNP) ---
 
 #[tokio::test]
-async fn pools_post_happy_and_missing_address_owner() {
+async fn pools_post_succeeds_missing_address_owner_rejected() {
     let st = app_state(empty_app_cfg(), None).await;
     let app = routes(false, st);
 
@@ -416,7 +413,7 @@ async fn pools_post_duplicate() {
 }
 
 #[tokio::test]
-async fn pools_delete_happy_and_referenced_by_binding() {
+async fn pools_delete_rejected_when_bound_then_succeeds_when_orphan() {
     let mut cfg = (*empty_app_cfg()).clone();
     let (nname, ncfg) = sample_node_adnl("p_del");
     cfg.nodes.insert(nname.clone(), ncfg);
@@ -458,7 +455,7 @@ async fn pools_delete_not_found() {
 // --- POST/DELETE /v1/bindings ---
 
 #[tokio::test]
-async fn bindings_post_happy_path_and_duplicate() {
+async fn bindings_post_succeeds_duplicate_rejected() {
     let mut cfg = (*empty_app_cfg()).clone();
     let (nname, ncfg) = sample_node_adnl("bind");
     cfg.nodes.insert(nname.clone(), ncfg);
@@ -519,7 +516,7 @@ async fn bindings_post_missing_refs() {
 }
 
 #[tokio::test]
-async fn bindings_delete_happy_and_non_idle() {
+async fn bindings_delete_succeeds_when_idle_non_idle_rejected() {
     let mut cfg = (*empty_app_cfg()).clone();
     let (nname, ncfg) = sample_node_adnl("idle_rm");
     cfg.nodes.insert(nname.clone(), ncfg.clone());

--- a/src/node-control/service/src/http/mod.rs
+++ b/src/node-control/service/src/http/mod.rs
@@ -16,3 +16,5 @@ pub use http_server_task::run;
 mod auth_tests;
 #[cfg(test)]
 mod config_handlers_tests;
+#[cfg(test)]
+mod entity_crud_handlers_tests;

--- a/src/node-control/service/src/runtime_config.rs
+++ b/src/node-control/service/src/runtime_config.rs
@@ -39,8 +39,9 @@ pub struct RuntimeConfigStore {
     state: RwLock<Arc<RuntimeState>>,
     /// Unix timestamp of the last config mutation (seconds).
     updated_at: AtomicU64,
-    /// Path to the config file on disk, used for save/reload.
-    config_path: String,
+    /// Path to the config file on disk, used for save/reload. `None` in tests
+    /// that construct an in-memory store via [`Self::from_app_config`].
+    config_path: Option<String>,
     /// Hash of the last config file content we loaded, to detect external changes.
     last_file_hash: Mutex<Option<u64>>,
 }
@@ -115,7 +116,7 @@ impl RuntimeConfigStore {
                 master_wallet,
             })),
             updated_at: AtomicU64::new(time_format::now()),
-            config_path,
+            config_path: Some(config_path),
             last_file_hash: Mutex::new(hash),
         })
     }
@@ -223,21 +224,17 @@ impl RuntimeConfigStore {
                 rpc_client,
             })),
             updated_at: AtomicU64::new(time_format::now()),
-            config_path: "noop".to_string(),
+            config_path: None,
             last_file_hash: Mutex::new(None),
         }
     }
 
-    /// Same as [`Self::from_app_config`], but writes persisted config to `config_path`
-    /// (for tests that assert on-disk config after `update_and_save`).
+    /// Test-only: enable on-disk persistence for an in-memory store. Use when a test
+    /// needs to assert the saved JSON after `update_and_save`.
     #[cfg(test)]
-    pub fn from_app_config_with_path(
-        app_config: Arc<AppConfig>,
-        config_path: impl Into<String>,
-    ) -> Self {
-        let mut store = Self::from_app_config(app_config);
-        store.config_path = config_path.into();
-        store
+    pub fn with_path(mut self, path: impl Into<String>) -> Self {
+        self.config_path = Some(path.into());
+        self
     }
 
     pub fn updated_at(&self) -> u64 {
@@ -299,7 +296,10 @@ impl RuntimeConfigStore {
     /// differs from the last write. Called from `update_and_save` so
     /// the disk write happens before the in-memory swap.
     fn save_to_file(&self, cfg: &AppConfig) -> anyhow::Result<()> {
-        let path = Path::new(&self.config_path);
+        let Some(path) = self.config_path.as_deref() else {
+            return Ok(());
+        };
+        let path = Path::new(path);
         let json = serde_json::to_string_pretty(cfg)
             .map_err(|e| anyhow::anyhow!("serialize config error: {e}"))?;
         let current_hash = Self::hash_bytes(json.as_bytes());
@@ -365,14 +365,17 @@ impl RuntimeConfigStore {
 
     /// Reload config from the file if it has changed externally.
     pub async fn reload_from_file(&self) -> bool {
-        let current_hash = Self::hash_file(&Path::new(&self.config_path));
+        let Some(path) = self.config_path.as_deref() else {
+            return false;
+        };
+        let current_hash = Self::hash_file(Path::new(path));
         let last_hash = *self.last_file_hash.lock().expect("last_file_hash lock");
         if current_hash == last_hash {
             return false;
         }
 
-        tracing::info!("config changed, reloading from '{}'", self.config_path);
-        match AppConfig::load(Path::new(&self.config_path)) {
+        tracing::info!("config changed, reloading from '{}'", path);
+        match AppConfig::load(Path::new(path)) {
             Ok(file_cfg) => match self.reload(file_cfg).await {
                 Ok(()) => {
                     *self.last_file_hash.lock().expect("last_file_hash lock") = current_hash;
@@ -384,7 +387,7 @@ impl RuntimeConfigStore {
                 }
             },
             Err(e) => {
-                tracing::error!("reload config error: path='{}' error={:#}", self.config_path, e);
+                tracing::error!("reload config error: path='{}' error={:#}", path, e);
                 false
             }
         }

--- a/src/node-control/service/src/runtime_config.rs
+++ b/src/node-control/service/src/runtime_config.rs
@@ -228,6 +228,18 @@ impl RuntimeConfigStore {
         }
     }
 
+    /// Same as [`Self::from_app_config`], but writes persisted config to `config_path`
+    /// (for tests that assert on-disk config after `update_and_save`).
+    #[cfg(test)]
+    pub fn from_app_config_with_path(
+        app_config: Arc<AppConfig>,
+        config_path: impl Into<String>,
+    ) -> Self {
+        let mut store = Self::from_app_config(app_config);
+        store.config_path = config_path.into();
+        store
+    }
+
     pub fn updated_at(&self) -> u64 {
         self.updated_at.load(Ordering::Relaxed)
     }


### PR DESCRIPTION
## Summary
Adds automated tests for the eight entity mutation REST endpoints (POST/DELETE for /v1/nodes, /v1/wallets, /v1/pools, /v1/bindings): happy paths, validation and conflict cases, persistence to disk after mutations, and role checks (nominator → 403, operator → allowed when auth is enabled).

## Changes
- `entity_crud_handlers_tests.rs` (new): Axum oneshot tests against routes(false, state) with RuntimeConfigStore::from_app_config, covering:
Nodes: add/list, duplicate, invalid base64 pubkey, delete success/not-found, delete blocked when referenced by a binding
Wallets: add/list, reserved master_wallet, duplicate, delete blocked when referenced by binding, delete success and not-found
Pools (SNP): add with address only, reject when both address and owner missing, duplicate name, delete blocked when referenced by binding, delete success and not-found
Bindings: add, duplicate, missing node/wallet/pool, delete when idle vs non-idle status, delete not-found
Persistence: temp config path + read-back JSON after POST/DELETE node mutations
- `runtime_config.rs`: #[cfg(test)] helper from_app_config_with_path so tests write config to a real temp file instead of the default "noop" path
- `auth_tests.rs`: delete_bearer helper; nominator_forbidden_on_entity_crud_routes (all eight mutations return 403); operator_can_mutate_entity_crud_when_auth_enabled (smoke: POST+DELETE node with operator JWT)
- `http/mod.rs`: wire new test module under #[cfg(test)]
