### PR TITLE
feat(secrets-vault): add mTLS support for HashiCorp Vault

### DIFF
--- a/src/secrets-vault/Cargo.toml
+++ b/src/secrets-vault/Cargo.toml
@@ -61,7 +61,7 @@ tokio = { version = "1", features = [
 ] }
 uuid = { version = "1", features = ["v4", "serde"] }
 zeroize = "1.8"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 base64 = "0.13"
 scopeguard = "1"
 rsa = { version = "0.9", features = ["sha2"], optional = true }

--- a/src/secrets-vault/src/storage/hashicorp_api.rs
+++ b/src/secrets-vault/src/storage/hashicorp_api.rs
@@ -229,7 +229,7 @@ impl Client {
             format!("https://{}", addr)
         };
 
-        let client = reqwest::Client::new();
+        let client = build_http_client()?;
         let vault_addr = format!("{addr}/v1");
         let token_provider = create_token_provider(auth, client.clone(), &vault_addr);
 
@@ -827,4 +827,33 @@ impl Client {
     pub fn escape(s: &str) -> String {
         s.replace('+', "-").replace('/', "_").trim_end_matches('=').to_string()
     }
+}
+
+/// Build an HTTP client with optional mTLS support.
+/// Reads VAULT_CACERT, VAULT_CLIENT_CERT, VAULT_CLIENT_KEY from environment.
+/// If not set, returns a default client.
+fn build_http_client() -> anyhow::Result<reqwest::Client> {
+    let mut builder = reqwest::Client::builder();
+
+    if let Ok(ca_path) = std::env::var("VAULT_CACERT") {
+        let ca_pem = std::fs::read(&ca_path)
+            .map_err(|e| anyhow::anyhow!("Failed to read VAULT_CACERT ({ca_path}): {e}"))?;
+        let cert = reqwest::Certificate::from_pem(&ca_pem)?;
+        builder = builder.add_root_certificate(cert);
+    }
+
+    if let (Ok(cert_path), Ok(key_path)) =
+        (std::env::var("VAULT_CLIENT_CERT"), std::env::var("VAULT_CLIENT_KEY"))
+    {
+        let cert_pem = std::fs::read(&cert_path)
+            .map_err(|e| anyhow::anyhow!("Failed to read VAULT_CLIENT_CERT ({cert_path}): {e}"))?;
+        let key_pem = std::fs::read(&key_path)
+            .map_err(|e| anyhow::anyhow!("Failed to read VAULT_CLIENT_KEY ({key_path}): {e}"))?;
+        let mut identity_pem = cert_pem;
+        identity_pem.extend_from_slice(&key_pem);
+        let identity = reqwest::Identity::from_pem(&identity_pem)?;
+        builder = builder.identity(identity);
+    }
+
+    Ok(builder.build()?)
 }


### PR DESCRIPTION
The secrets-vault library currently creates a plain `reqwest::Client::new()` when connecting to HashiCorp Vault. This fails when Vault is behind an ingress that requires mutual TLS (mTLS) client certificate authentication.

This PR adds support for the standard HashiCorp Vault TLS environment variables:

  - `VAULT_CACERT` — path to a custom CA certificate (PEM)
  - `VAULT_CLIENT_CERT` — path to a client certificate (PEM)
  - `VAULT_CLIENT_KEY` — path to a client private key (PEM)

When these variables are set, the HTTP client is built with the corresponding TLS configuration. When they are not set, the client behaves exactly as before (no breaking change).