### PR TITLE
fix: serialize TaskController lifecycle ops to prevent orphaned election tasks

### DIFF
--- a/src/node-control/service/src/task/task_manager.rs
+++ b/src/node-control/service/src/task/task_manager.rs
@@ -455,7 +455,7 @@ mod tests {
     /// zero after `disable()`). Not deterministic — relies on the scheduler
     /// producing a bad interleave under the old code; passes more reliably
     /// on multi-core runners. Treat as a regression guard, not a proof.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     async fn concurrent_restarts_do_not_orphan_tasks() {
         struct LiveCountTask {
             live: Arc<AtomicU32>,
@@ -494,7 +494,7 @@ mod tests {
             }));
         }
         for j in joins {
-            let _ = j.await;
+            j.await.expect("restart task panicked");
         }
 
         // Give the most recent restart a moment to spawn.

--- a/src/node-control/service/src/task/task_manager.rs
+++ b/src/node-control/service/src/task/task_manager.rs
@@ -103,6 +103,7 @@ impl TaskController {
         self.enable_locked()
     }
 
+    /// Caller must hold `self.lifecycle`.
     fn enable_locked(&self) -> TaskStateView {
         let mut st = self.state.lock().expect("failed to lock state");
 
@@ -144,6 +145,7 @@ impl TaskController {
         self.disable_locked().await
     }
 
+    /// Caller must hold `self.lifecycle`.
     async fn disable_locked(&self) -> TaskStateView {
         let handle_to_await = {
             let mut st = self.state.lock().expect("failed to lock state");
@@ -448,10 +450,11 @@ mod tests {
         ctrl.disable().await;
     }
 
-    /// Regression test for SMA-89: concurrent `restart()` calls must not
-    /// orphan a spawned task. Before the lifecycle lock, two interleaved
-    /// restarts could leave a task running with no handle/cancel pointing
-    /// at it; after `disable()` the live count would stay above zero.
+    /// Smoke test for concurrent `restart()` calls: stresses 8 parallel
+    /// restarts and asserts no task is orphaned (exactly one live during,
+    /// zero after `disable()`). Not deterministic — relies on the scheduler
+    /// producing a bad interleave under the old code; passes more reliably
+    /// on multi-core runners. Treat as a regression guard, not a proof.
     #[tokio::test]
     async fn concurrent_restarts_do_not_orphan_tasks() {
         struct LiveCountTask {

--- a/src/node-control/service/src/task/task_manager.rs
+++ b/src/node-control/service/src/task/task_manager.rs
@@ -63,6 +63,12 @@ pub struct TaskController {
     name: &'static str,
     task: Arc<dyn ServiceTask>,
     state: Mutex<State>,
+    /// Serializes the full enable/disable/restart flow so concurrent callers
+    /// cannot interleave (which would orphan tasks).
+    /// Why: `disable()` releases `state` across its `handle.await`; without
+    /// this outer lock, a second caller can race in, spawn a task, and have
+    /// its bookkeeping overwritten by the first caller resuming.
+    lifecycle: tokio::sync::Mutex<()>,
     runtime_cfg: Arc<dyn RuntimeConfig>,
 }
 
@@ -82,6 +88,7 @@ impl TaskController {
                 cancel: None,
                 handle: None,
             }),
+            lifecycle: tokio::sync::Mutex::new(()),
             runtime_cfg,
         }
     }
@@ -92,6 +99,11 @@ impl TaskController {
     }
 
     pub async fn enable(&self) -> TaskStateView {
+        let _guard = self.lifecycle.lock().await;
+        self.enable_locked()
+    }
+
+    fn enable_locked(&self) -> TaskStateView {
         let mut st = self.state.lock().expect("failed to lock state");
 
         st.enabled = true;
@@ -128,6 +140,11 @@ impl TaskController {
     }
 
     pub async fn disable(&self) -> TaskStateView {
+        let _guard = self.lifecycle.lock().await;
+        self.disable_locked().await
+    }
+
+    async fn disable_locked(&self) -> TaskStateView {
         let handle_to_await = {
             let mut st = self.state.lock().expect("failed to lock state");
             st.enabled = false;
@@ -166,8 +183,9 @@ impl TaskController {
     }
 
     pub async fn restart(&self) -> TaskStateView {
-        let _ = self.disable().await;
-        self.enable().await
+        let _guard = self.lifecycle.lock().await;
+        let _ = self.disable_locked().await;
+        self.enable_locked()
     }
 }
 
@@ -428,6 +446,71 @@ mod tests {
         assert_eq!(count.load(Ordering::SeqCst), 2, "task should have been started twice");
 
         ctrl.disable().await;
+    }
+
+    /// Regression test for SMA-89: concurrent `restart()` calls must not
+    /// orphan a spawned task. Before the lifecycle lock, two interleaved
+    /// restarts could leave a task running with no handle/cancel pointing
+    /// at it; after `disable()` the live count would stay above zero.
+    #[tokio::test]
+    async fn concurrent_restarts_do_not_orphan_tasks() {
+        struct LiveCountTask {
+            live: Arc<AtomicU32>,
+        }
+
+        #[async_trait::async_trait]
+        impl ServiceTask for LiveCountTask {
+            async fn run(
+                &self,
+                ctx: CancellationCtx,
+                _app_config: Arc<AppConfig>,
+            ) -> anyhow::Result<()> {
+                self.live.fetch_add(1, Ordering::SeqCst);
+                let mut rx = ctx.subscribe();
+                let _ = rx.changed().await;
+                self.live.fetch_sub(1, Ordering::SeqCst);
+                Ok(())
+            }
+        }
+
+        let live = Arc::new(AtomicU32::new(0));
+        let ctrl = Arc::new(TaskController::new(
+            "test",
+            LiveCountTask { live: live.clone() },
+            runtime_config(),
+        ));
+
+        ctrl.enable().await;
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        let mut joins = Vec::new();
+        for _ in 0..8 {
+            let c = ctrl.clone();
+            joins.push(tokio::spawn(async move {
+                c.restart().await;
+            }));
+        }
+        for j in joins {
+            let _ = j.await;
+        }
+
+        // Give the most recent restart a moment to spawn.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert_eq!(
+            live.load(Ordering::SeqCst),
+            1,
+            "exactly one task instance should be live after concurrent restarts"
+        );
+
+        ctrl.disable().await;
+        // After disable, the single live task must observe cancellation and exit.
+        // If any restart had orphaned a task, its live counter would remain > 0.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert_eq!(
+            live.load(Ordering::SeqCst),
+            0,
+            "no orphaned tasks should remain alive after disable"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

`config elections enable/include/exclude` HTTP handlers fire `tokio::spawn(restart())` without serialization. `TaskController::restart()` is `disable().await; enable().await` with the inner `std::sync::Mutex<State>` released between phases (and dropped across `handle.await`). Two concurrent restarts can interleave such that a task is spawned by caller B, then its `cancel`/`handle` are overwritten by caller A's resumed `enable()` — orphaning B's task until process shutdown.

## Fix

Add a `tokio::sync::Mutex<()>` (`lifecycle`) to `TaskController`. Public `enable` / `disable` / `restart` each acquire it first, then delegate to private `_locked` helpers (original bodies unchanged). `restart()` now holds the lock across the full disable→enable sequence, so concurrent callers queue instead of racing.

The existing `std::sync::Mutex<State>` is kept for short critical sections so `status()` stays non-blocking and isn't held back by long-running lifecycle work.

## Scope (deliberately minimal)

- HTTP handlers still use detached `tokio::spawn(restart())` — now safe because restarts queue on `lifecycle`. Switching them to `await` would block the HTTP response on restart duration, which is a separate UX decision.
- The "config read at spawn time" ordering note from the ticket is not addressed — harmless once atomicity is fixed.

Closes SMA-89