### PR TITLE
Fix/toncore get pool data empty dicts

### DIFF
--- a/src/node-control/common/src/tvm_stack_parser.rs
+++ b/src/node-control/common/src/tvm_stack_parser.rs
@@ -88,9 +88,6 @@ impl TvmStackParser {
         if let StackEntry::Tvm_StackEntryUnsupported = entry {
             return Ok(None);
         }
-        if entry.number().is_some() {
-            return Ok(None);
-        }
         if let Some(list) = entry.list() {
             let elements = list.elements();
             if elements.is_empty() {

--- a/src/node-control/common/src/tvm_stack_parser.rs
+++ b/src/node-control/common/src/tvm_stack_parser.rs
@@ -81,7 +81,7 @@ impl TvmStackParser {
 
     /// Optional dictionary cell from TONCore `get_pool_data` (`nominators`, `withdraw_requests`).
     ///
-    /// Rust node JSON-RPC encodes an **empty** dict as integer `0`, an empty `tvm.list`, or `null`
+    /// Rust node JSON-RPC encodes an **empty** dict as an empty `tvm.list`, or `null`
     /// (`Unsupported`). A cell (or a non-empty list wrapping a cell) means a non-empty dict on chain.
     pub fn dict_cell_opt(&self, index: usize) -> anyhow::Result<Option<Cell>> {
         let entry = self.entry(index)?;

--- a/src/node-control/common/src/tvm_stack_parser.rs
+++ b/src/node-control/common/src/tvm_stack_parser.rs
@@ -66,24 +66,13 @@ impl TvmStackParser {
         Ok(cell)
     }
 
-    pub fn cell_opt(&self, index: usize) -> anyhow::Result<Option<Cell>> {
-        let entry = self.entry(index)?;
-        if let StackEntry::Tvm_StackEntryUnsupported = entry {
-            return Ok(None);
-        }
-        let boc = entry
-            .cell()
-            .ok_or_else(|| anyhow::anyhow!("stack entry is not a cell: index={}", index))?;
-        let cell = read_single_root_boc(&boc.bytes)
-            .map_err(|e| anyhow::anyhow!("invalid boc: index={}: {}", index, e))?;
-        Ok(Some(cell))
-    }
-
-    /// Optional dictionary cell from TONCore `get_pool_data` (`nominators`, `withdraw_requests`).
+    /// Optional cell entry.
     ///
-    /// Rust node JSON-RPC encodes an **empty** dict as an empty `tvm.list`, or `null`
-    /// (`Unsupported`). A cell (or a non-empty list wrapping a cell) means a non-empty dict on chain.
-    pub fn dict_cell_opt(&self, index: usize) -> anyhow::Result<Option<Cell>> {
+    /// Handles all empty-cell shapes the rust node's JSON-RPC may produce for TVM stack
+    /// entries — including TONCore `get_pool_data` dicts (`nominators`, `withdraw_requests`):
+    /// `null` (`Unsupported`) and an empty `tvm.list { elements: [] }` both decode to `None`.
+    /// A non-empty dict arrives as a cell, optionally wrapped in a single-element list.
+    pub fn cell_opt(&self, index: usize) -> anyhow::Result<Option<Cell>> {
         let entry = self.entry(index)?;
         if let StackEntry::Tvm_StackEntryUnsupported = entry {
             return Ok(None);
@@ -94,12 +83,12 @@ impl TvmStackParser {
                 return Ok(None);
             }
             return Self::new(elements.to_vec())
-                .dict_cell_opt(0)
-                .with_context(|| format!("parse dict cell inside list at index={index}"));
+                .cell_opt(0)
+                .with_context(|| format!("parse cell inside list at index={index}"));
         }
-        let boc = entry.cell().ok_or_else(|| {
-            anyhow::anyhow!("stack entry is not an optional dict cell: index={}", index)
-        })?;
+        let boc = entry
+            .cell()
+            .ok_or_else(|| anyhow::anyhow!("stack entry is not a cell: index={}", index))?;
         let cell = read_single_root_boc(&boc.bytes)
             .map_err(|e| anyhow::anyhow!("invalid boc: index={}: {}", index, e))?;
         Ok(Some(cell))
@@ -662,33 +651,51 @@ mod tests {
     }
 
     #[test]
-    fn test_dict_cell_opt_empty_as_number() {
-        let stack = vec![create_number_entry("0")];
-        let parser = TvmStackParser::new(stack);
-        assert!(parser.dict_cell_opt(0).unwrap().is_none());
-    }
-
-    #[test]
-    fn test_dict_cell_opt_empty_as_list() {
-        let stack = vec![create_list_entry(vec![])];
-        let parser = TvmStackParser::new(stack);
-        assert!(parser.dict_cell_opt(0).unwrap().is_none());
-    }
-
-    #[test]
-    fn test_dict_cell_opt_unsupported() {
+    fn test_cell_opt_unsupported_is_none() {
         let stack = vec![create_unsupported_entry()];
         let parser = TvmStackParser::new(stack);
-        assert!(parser.dict_cell_opt(0).unwrap().is_none());
+        assert!(parser.cell_opt(0).unwrap().is_none());
     }
 
     #[test]
-    fn test_dict_cell_opt_non_empty_cell() {
+    fn test_cell_opt_empty_list_is_none() {
+        let stack = vec![create_list_entry(vec![])];
+        let parser = TvmStackParser::new(stack);
+        assert!(parser.cell_opt(0).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_cell_opt_cell_directly() {
         let cell = Cell::default();
         let stack = vec![create_cell_entry(&cell)];
         let parser = TvmStackParser::new(stack);
-        let parsed = parser.dict_cell_opt(0).unwrap().expect("expected cell");
+        let parsed = parser.cell_opt(0).unwrap().expect("expected cell");
         assert_eq!(parsed.repr_hash(), cell.repr_hash());
+    }
+
+    #[test]
+    fn test_cell_opt_list_wrapping_cell() {
+        let cell = Cell::default();
+        let stack = vec![create_list_entry(vec![create_cell_entry(&cell)])];
+        let parser = TvmStackParser::new(stack);
+        let parsed = parser.cell_opt(0).unwrap().expect("expected cell");
+        assert_eq!(parsed.repr_hash(), cell.repr_hash());
+    }
+
+    #[test]
+    fn test_cell_opt_rejects_number() {
+        let stack = vec![create_number_entry("0")];
+        let parser = TvmStackParser::new(stack);
+        let err = parser.cell_opt(0).unwrap_err().to_string();
+        assert!(err.contains("stack entry is not a cell"));
+    }
+
+    #[test]
+    fn test_cell_opt_rejects_tuple() {
+        let stack = vec![create_tuple_entry(vec![])];
+        let parser = TvmStackParser::new(stack);
+        let err = parser.cell_opt(0).unwrap_err().to_string();
+        assert!(err.contains("stack entry is not a cell"));
     }
 
     #[test]

--- a/src/node-control/common/src/tvm_stack_parser.rs
+++ b/src/node-control/common/src/tvm_stack_parser.rs
@@ -79,6 +79,35 @@ impl TvmStackParser {
         Ok(Some(cell))
     }
 
+    /// Optional dictionary cell from TONCore `get_pool_data` (`nominators`, `withdraw_requests`).
+    ///
+    /// Rust node JSON-RPC encodes an **empty** dict as integer `0`, an empty `tvm.list`, or `null`
+    /// (`Unsupported`). A cell (or a non-empty list wrapping a cell) means a non-empty dict on chain.
+    pub fn dict_cell_opt(&self, index: usize) -> anyhow::Result<Option<Cell>> {
+        let entry = self.entry(index)?;
+        if let StackEntry::Tvm_StackEntryUnsupported = entry {
+            return Ok(None);
+        }
+        if entry.number().is_some() {
+            return Ok(None);
+        }
+        if let Some(list) = entry.list() {
+            let elements = list.elements();
+            if elements.is_empty() {
+                return Ok(None);
+            }
+            return Self::new(elements.to_vec())
+                .dict_cell_opt(0)
+                .with_context(|| format!("parse dict cell inside list at index={index}"));
+        }
+        let boc = entry.cell().ok_or_else(|| {
+            anyhow::anyhow!("stack entry is not an optional dict cell: index={}", index)
+        })?;
+        let cell = read_single_root_boc(&boc.bytes)
+            .map_err(|e| anyhow::anyhow!("invalid boc: index={}: {}", index, e))?;
+        Ok(Some(cell))
+    }
+
     pub fn i64(&self, index: usize) -> anyhow::Result<i64> {
         let mut decimal = self.decimal_string(index)?;
         let minus = if decimal.starts_with("-") {
@@ -633,6 +662,36 @@ mod tests {
         let result = parser.cell(0);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("stack entry is not a cell"));
+    }
+
+    #[test]
+    fn test_dict_cell_opt_empty_as_number() {
+        let stack = vec![create_number_entry("0")];
+        let parser = TvmStackParser::new(stack);
+        assert!(parser.dict_cell_opt(0).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_dict_cell_opt_empty_as_list() {
+        let stack = vec![create_list_entry(vec![])];
+        let parser = TvmStackParser::new(stack);
+        assert!(parser.dict_cell_opt(0).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_dict_cell_opt_unsupported() {
+        let stack = vec![create_unsupported_entry()];
+        let parser = TvmStackParser::new(stack);
+        assert!(parser.dict_cell_opt(0).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_dict_cell_opt_non_empty_cell() {
+        let cell = Cell::default();
+        let stack = vec![create_cell_entry(&cell)];
+        let parser = TvmStackParser::new(stack);
+        let parsed = parser.dict_cell_opt(0).unwrap().expect("expected cell");
+        assert_eq!(parsed.repr_hash(), cell.repr_hash());
     }
 
     #[test]

--- a/src/node-control/contracts/src/nominator/ton_core_nominator.rs
+++ b/src/node-control/contracts/src/nominator/ton_core_nominator.rs
@@ -264,10 +264,12 @@ impl NominatorWrapper for TonCoreNominatorWrapper {
         let max_nominators_count = stack.i64(6).context("parse max_nominators_count")? as u16;
         let min_validator_stake = stack.i64(7).context("parse min_validator_stake")? as u64;
         let min_nominator_stake = stack.i64(8).context("parse min_nominator_stake")? as u64;
-        // Indices 9–10: `nominators` / `withdraw_requests` dicts. Empty dicts may appear as int 0
-        // over JSON-RPC (see `TvmStackParser::dict_cell_opt`). `Some(_)` at 10 = pending withdraws.
-        let _nominators = stack.dict_cell_opt(9).context("parse nominators")?;
-        let withdraw_requests = stack.dict_cell_opt(10).context("parse withdraw_requests")?;
+        // Indices 9–10: `nominators` / `withdraw_requests` dicts (empty dicts arrive as empty
+        // `tvm.list`, see `TvmStackParser::cell_opt`). Index 9 is parsed only as a layout probe:
+        // if the stack ever shifts, this errors before we silently misread index 10. `Some(_)` at
+        // 10 means there is at least one pending withdraw request.
+        let _nominators = stack.cell_opt(9).context("parse nominators")?;
+        let withdraw_requests = stack.cell_opt(10).context("parse withdraw_requests")?;
         let stake_at = stack.i64(11).context("parse stake_at")? as u32;
         let saved_validator_set_hash = {
             let bytes = stack.number_bytes(12, 32).context("parse saved_validator_set_hash")?;

--- a/src/node-control/contracts/src/nominator/ton_core_nominator.rs
+++ b/src/node-control/contracts/src/nominator/ton_core_nominator.rs
@@ -264,10 +264,10 @@ impl NominatorWrapper for TonCoreNominatorWrapper {
         let max_nominators_count = stack.i64(6).context("parse max_nominators_count")? as u16;
         let min_validator_stake = stack.i64(7).context("parse min_validator_stake")? as u64;
         let min_nominator_stake = stack.i64(8).context("parse min_nominator_stake")? as u64;
-        // Index 9 is `nominators:dict` (not currently used). Index 10 is `withdraw_requests:dict`
-        // from `pool.fc` persistent storage; `Some(_)` means at least one nominator has a
-        // pending withdraw request (see `has_withdraw_requests`).
-        let withdraw_requests = stack.cell_opt(10).context("parse withdraw_requests")?;
+        // Indices 9–10: `nominators` / `withdraw_requests` dicts. Empty dicts may appear as int 0
+        // over JSON-RPC (see `TvmStackParser::dict_cell_opt`). `Some(_)` at 10 = pending withdraws.
+        let _nominators = stack.dict_cell_opt(9).context("parse nominators")?;
+        let withdraw_requests = stack.dict_cell_opt(10).context("parse withdraw_requests")?;
         let stake_at = stack.i64(11).context("parse stake_at")? as u32;
         let saved_validator_set_hash = {
             let bytes = stack.number_bytes(12, 32).context("parse saved_validator_set_hash")?;

--- a/src/node-control/service/src/elections/runner.rs
+++ b/src/node-control/service/src/elections/runner.rs
@@ -332,11 +332,7 @@ impl ElectionRunner {
     /// Fill `node.pool_addr_cache` if the node has a pool but no cached address.
     /// On failure the node is appended to `skip_tick_nodes` so participation is deferred
     /// to the next tick; the next tick's resolve pass will retry.
-    async fn resolve_pool_addr(
-        node_id: &str,
-        node: &mut Node,
-        skip_tick_nodes: &mut Vec<String>,
-    ) {
+    async fn resolve_pool_addr(node_id: &str, node: &mut Node, skip_tick_nodes: &mut Vec<String>) {
         let Some(pool) = &node.pool else {
             node.pool_addr_cache = None;
             return;
@@ -534,13 +530,7 @@ impl ElectionRunner {
         // transition. SNP pool addresses are stable but invalidating uniformly is cheap.
         // Also covers elections-task restart: `past_elections_cache_id` is 0 after start, so the
         // first tick lands here and re-resolves.
-        if self.past_elections_cache_id != election_id {
-            for node in self.nodes.values_mut() {
-                if node.pool.is_some() {
-                    node.pool_addr_cache = None;
-                }
-            }
-        }
+        if self.past_elections_cache_id != election_id {}
         // Resolve pool address for any node where it isn't cached yet. On election_id transition
         // the cache was just invalidated above; on other ticks this recovers from a transient
         // `pool.address()` failure (e.g. a `get_pool_data` parse error on TONCore).
@@ -596,6 +586,11 @@ impl ElectionRunner {
                     "prev_min_eff_stake from past elections: {} TON",
                     nanotons_to_tons_f64(prev)
                 );
+            }
+            for node in self.nodes.values_mut() {
+                if node.pool.is_some() {
+                    node.pool_addr_cache = None;
+                }
             }
             self.past_elections_cache_id = election_id;
         }

--- a/src/node-control/service/src/elections/runner.rs
+++ b/src/node-control/service/src/elections/runner.rs
@@ -530,7 +530,13 @@ impl ElectionRunner {
         // transition. SNP pool addresses are stable but invalidating uniformly is cheap.
         // Also covers elections-task restart: `past_elections_cache_id` is 0 after start, so the
         // first tick lands here and re-resolves.
-        if self.past_elections_cache_id != election_id {}
+        if self.past_elections_cache_id != election_id {
+            for node in self.nodes.values_mut() {
+                if node.pool.is_some() {
+                    node.pool_addr_cache = None;
+                }
+            }
+        }
         // Resolve pool address for any node where it isn't cached yet. On election_id transition
         // the cache was just invalidated above; on other ticks this recovers from a transient
         // `pool.address()` failure (e.g. a `get_pool_data` parse error on TONCore).
@@ -586,11 +592,6 @@ impl ElectionRunner {
                     "prev_min_eff_stake from past elections: {} TON",
                     nanotons_to_tons_f64(prev)
                 );
-            }
-            for node in self.nodes.values_mut() {
-                if node.pool.is_some() {
-                    node.pool_addr_cache = None;
-                }
             }
             self.past_elections_cache_id = election_id;
         }

--- a/src/node-control/service/src/elections/runner.rs
+++ b/src/node-control/service/src/elections/runner.rs
@@ -146,10 +146,28 @@ struct Node {
 }
 
 impl Node {
-    /// Get theaddress from which the stake will be sent to elector: pool or wallet.
+    /// Resolved pool target for this node.
+    /// - `Ok(None)` — direct staking (no pool configured).
+    /// - `Ok(Some(addr))` — staking via pool at `addr`.
+    /// - `Err` — pool is configured but its address is not cached yet. This is transient:
+    ///   the next tick's resolve loop will retry. Callers should propagate the error so
+    ///   the node is not silently downgraded to wallet-based staking.
+    fn pool_target(&self) -> anyhow::Result<Option<&MsgAddressInt>> {
+        match (&self.pool, &self.pool_addr_cache) {
+            (None, _) => Ok(None),
+            (Some(_), Some(addr)) => Ok(Some(addr)),
+            (Some(_), None) => {
+                Err(anyhow::anyhow!("pool address not resolved; will retry next tick"))
+            }
+        }
+    }
+
+    /// Get the address from which the stake will be sent to elector: pool or wallet.
+    /// Errors if pool is configured but its address has not been resolved yet — preventing
+    /// a misroute to wallet-based staking when the pool address cache is transiently empty.
     /// Note: only raw address bytes are returned (without workchain ID).
     async fn stake_addr(&self) -> anyhow::Result<Vec<u8>> {
-        Ok(match &self.pool_addr_cache {
+        Ok(match self.pool_target()? {
             Some(addr) => addr.address().storage().to_vec(),
             None => self.wallet.address().await?.address().storage().to_vec(),
         })
@@ -311,6 +329,33 @@ struct StakeContext<'a> {
 }
 
 impl ElectionRunner {
+    /// Fill `node.pool_addr_cache` if the node has a pool but no cached address.
+    /// On failure the node is appended to `skip_tick_nodes` so participation is deferred
+    /// to the next tick; the next tick's resolve pass will retry.
+    async fn resolve_pool_addr(
+        node_id: &str,
+        node: &mut Node,
+        skip_tick_nodes: &mut Vec<String>,
+    ) {
+        let Some(pool) = &node.pool else {
+            node.pool_addr_cache = None;
+            return;
+        };
+        if node.pool_addr_cache.is_some() {
+            return;
+        }
+        match pool.address().await {
+            Ok(addr) => {
+                tracing::info!("node [{}] pool address cached: {}", node_id, addr);
+                node.pool_addr_cache = Some(addr);
+            }
+            Err(e) => {
+                tracing::error!("node [{}] pool address error: {}", node_id, e);
+                skip_tick_nodes.push(node_id.to_string());
+            }
+        }
+    }
+
     pub(crate) fn new(
         elections_config: &ElectionsConfig,
         bindings: &HashMap<String, NodeBinding>,
@@ -481,14 +526,41 @@ impl ElectionRunner {
 
         self.build_elections_snapshot(election_id, &cfg15, &elections_info, &cfg17).await;
 
+        let mut skip_tick_nodes = vec![];
+
+        // Pool address cache must be valid before any branch that uses `stake_addr`/`pool_target`
+        // (the finished branch below included). TONCore router pool address changes per election
+        // cycle (the router alternates between two pools), so invalidate the cache on election_id
+        // transition. SNP pool addresses are stable but invalidating uniformly is cheap.
+        // Also covers elections-task restart: `past_elections_cache_id` is 0 after start, so the
+        // first tick lands here and re-resolves.
+        if self.past_elections_cache_id != election_id {
+            for node in self.nodes.values_mut() {
+                if node.pool.is_some() {
+                    node.pool_addr_cache = None;
+                }
+            }
+        }
+        // Resolve pool address for any node where it isn't cached yet. On election_id transition
+        // the cache was just invalidated above; on other ticks this recovers from a transient
+        // `pool.address()` failure (e.g. a `get_pool_data` parse error on TONCore).
+        for (node_id, node) in self.nodes.iter_mut() {
+            Self::resolve_pool_addr(node_id, node, &mut skip_tick_nodes).await;
+        }
+
         if elections_info.finished {
             self.snapshot_cache.last_elections_status = ElectionsStatus::Finished;
             tracing::warn!("elections are finished");
             // check if node stakes are accepted by the elector
-            for node in self.nodes.values_mut() {
+            for (node_id, node) in self.nodes.iter_mut() {
                 // Reset previous state; only mark as accepted if present in current participants
                 node.stake_accepted = false;
                 node.accepted_stake_amount = None;
+                // Skip nodes whose pool address didn't resolve this tick: we cannot determine
+                // the correct staking address, and the next tick will retry.
+                if skip_tick_nodes.contains(node_id) {
+                    continue;
+                }
 
                 let staking_addr = node.stake_addr().await?;
                 if let Some(p) =
@@ -511,7 +583,6 @@ impl ElectionRunner {
             self.snapshot_cache.last_elections_status = ElectionsStatus::Postponed;
         }
 
-        let mut skip_tick_nodes = vec![];
         // Fetch past_elections only when election_id changes (cache across ticks).
         if self.past_elections_cache_id != election_id {
             self.past_elections = self.elector.past_elections().await.context("past_elections")?;
@@ -526,44 +597,7 @@ impl ElectionRunner {
                     nanotons_to_tons_f64(prev)
                 );
             }
-            // Cache pool address for each node:
-            // for TONCore pool getting address is a network RPC call,
-            //for SNP pool - its a simple getter.
-            for (node_id, node) in self.nodes.iter_mut() {
-                node.pool_addr_cache = if let Some(p) = &node.pool {
-                    match p.address().await {
-                        Ok(addr) => Some(addr),
-                        Err(e) => {
-                            tracing::error!("node [{}] pool address error: {}", node_id, e);
-                            skip_tick_nodes.push(node_id.clone());
-                            None
-                        }
-                    }
-                } else {
-                    None
-                }
-            }
-            // Apply new election id only if all data was requested successfully.
             self.past_elections_cache_id = election_id;
-        }
-
-        // Pool address is cached only on election_id transition. If the first attempt failed
-        // (e.g. get_pool_data parse error on TONCore), retry every tick until resolved.
-        for (node_id, node) in self.nodes.iter_mut() {
-            if node.pool.is_none() || node.pool_addr_cache.is_some() {
-                continue;
-            }
-            let Some(p) = &node.pool else { continue };
-            match p.address().await {
-                Ok(addr) => {
-                    tracing::info!("node [{}] pool address cached: {}", node_id, addr);
-                    node.pool_addr_cache = Some(addr);
-                }
-                Err(e) => {
-                    tracing::error!("node [{}] pool address error: {}", node_id, e);
-                    skip_tick_nodes.push(node_id.clone());
-                }
-            }
         }
 
         // walk through the nodes and try to participate in the elections
@@ -732,8 +766,10 @@ impl ElectionRunner {
         // Resolve target once per tick:
         // if pool address is cached use it, otherwise fallback to elector.
         let elector_addr = self.elector.address().await?;
-        // address to which the wallet will send stake request: pool or elector
-        let to_addr = node.pool_addr_cache.as_ref().cloned().unwrap_or(elector_addr);
+        // address to which the wallet will send stake request: pool or elector.
+        // `pool_target()?` errors if pool is configured but its address is not yet cached —
+        // this prevents the request from being misrouted directly to the elector.
+        let to_addr = node.pool_target()?.cloned().unwrap_or(elector_addr);
         // address from which the stake will be sent to elector: wallet or pool
         let from_addr = node.stake_addr().await?;
         // Find validator key for current elections in the validator config
@@ -1098,7 +1134,9 @@ impl ElectionRunner {
                 );
             }
             let elector_addr = self.elector.address().await?;
-            let to_addr = node.pool_addr_cache.as_ref().cloned().unwrap_or(elector_addr);
+            // pool_target() errors if pool is set but its address is not cached yet — avoids
+            // routing recover stake to the elector when the pool is actually configured.
+            let to_addr = node.pool_target()?.cloned().unwrap_or(elector_addr);
             let msg_boc = write_boc(
                 &node
                     .wallet

--- a/src/node-control/service/src/elections/runner.rs
+++ b/src/node-control/service/src/elections/runner.rs
@@ -547,6 +547,25 @@ impl ElectionRunner {
             self.past_elections_cache_id = election_id;
         }
 
+        // Pool address is cached only on election_id transition. If the first attempt failed
+        // (e.g. get_pool_data parse error on TONCore), retry every tick until resolved.
+        for (node_id, node) in self.nodes.iter_mut() {
+            if node.pool.is_none() || node.pool_addr_cache.is_some() {
+                continue;
+            }
+            let Some(p) = &node.pool else { continue };
+            match p.address().await {
+                Ok(addr) => {
+                    tracing::info!("node [{}] pool address cached: {}", node_id, addr);
+                    node.pool_addr_cache = Some(addr);
+                }
+                Err(e) => {
+                    tracing::error!("node [{}] pool address error: {}", node_id, e);
+                    skip_tick_nodes.push(node_id.clone());
+                }
+            }
+        }
+
         // walk through the nodes and try to participate in the elections
         let mut nodes = self
             .nodes

--- a/src/node/tests/test_load_net/scripts/singlehost-config-proposal-p15.json
+++ b/src/node/tests/test_load_net/scripts/singlehost-config-proposal-p15.json
@@ -1,0 +1,8 @@
+{
+    "p15": {
+        "validators_elected_for": 600,
+        "elections_start_before": 421,
+        "elections_end_before": 120,
+        "stake_held_for": 180
+    }
+}

--- a/src/node/tests/test_load_net/scripts/topup.ts
+++ b/src/node/tests/test_load_net/scripts/topup.ts
@@ -59,7 +59,7 @@ async function run() {
     });
     console.log(`Sent ${fromNano(amount)} TON to ${address}, waiting for balance update...`);
 
-    const timeout = 300_000;
+    const timeout = 600_000;
     const poll = 1_000;
     const start = Date.now();
     while (Date.now() - start < timeout) {

--- a/src/node/tests/test_run_net_py/run_singlehost_nodectl.py
+++ b/src/node/tests/test_run_net_py/run_singlehost_nodectl.py
@@ -758,12 +758,12 @@ class Bootstrap:
             return ""
 
     def _bun_topup(self, address: str, amount: str) -> None:
-        # Keep subprocess timeout above topup.ts post-send balance poll (60s hardcoded) + margin.
-        timeout_raw = os.environ.get("BUN_TOPUP_TIMEOUT_SECONDS", "400")
+        # Keep subprocess timeout above topup.ts post-send balance poll (600s) + margin.
+        timeout_raw = os.environ.get("BUN_TOPUP_TIMEOUT_SECONDS", "720")
         try:
             timeout = int(timeout_raw)
         except ValueError:
-            timeout = 400
+            timeout = 720
         subprocess.run(["bun", "run", "topup", address, amount],
                        cwd=self.paths.load_net_dir, check=True,
                        stdin=subprocess.DEVNULL, timeout=timeout)


### PR DESCRIPTION
## Summary

Fixes TONCore validator participation on singlehost after regressions from #139:
empty pool dict fields no longer break `get_pool_data`, and elections recover pool
addresses after transient RPC/parse failures. Extends wallet top-up timeouts so
phase 10/11 bootstrap does not fail on slow localnets.

## Changes

### nodectl
- `dict_cell_opt` for optional dict stack entries; wired into TONCore `get_pool_data`.
- Elections runner: repopulate `pool_addr_cache` when pool is set but cache is empty.

### singlehost E2E
- `topup.ts`: balance wait 300s → 600s.
- `run_singlehost_nodectl.py`: `BUN_TOPUP_TIMEOUT_SECONDS` default 400 → 720.