### PR TITLE
fix(block): enable vendored openssl to fix nodectl windows build

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -3531,6 +3531,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.0+3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3538,6 +3547,7 @@ checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/src/block/Cargo.toml
+++ b/src/block/Cargo.toml
@@ -31,7 +31,7 @@ p256 = "0.13.2"
 rand = '0.8'
 secp256k1 = { version = '0.30', features = [ 'recovery', 'global-context' ] }
 serde = { features = [ 'derive', 'rc' ], version = '1.0.105' }
-openssl = "0.10"
+openssl = { version = "0.10", features = ["vendored"] }
 sha2 = '0.10'
 smallvec = { features = [ 'const_new', 'union', 'write' ], version = '1.10' }
 thiserror = '1.0'


### PR DESCRIPTION
## Context

The Windows binary for `nodectl` failed to build in `Publish nodectl` workflow:
https://github.com/RSquad/ton-rust-node/actions/runs/26028077294/job/76506563675

`openssl-sys v0.9.112` could not locate an OpenSSL installation on the `windows-latest` runner (no `OPENSSL_DIR`, no `VCPKG_ROOT`), and the workflow only installs `libssl-dev` on Linux.

## Dependency path

```
nodectl → adnl → ton_block → openssl → openssl-sys
```

`openssl` is declared in `src/block/Cargo.toml`, which is outside `node-control`. Touching it here intentionally — the `nodectl` Windows release artifact depends on it transitively.

## Change

Enable the `vendored` feature on the `openssl` dependency in `src/block/Cargo.toml`. `openssl-sys` then builds OpenSSL from vendored sources via the `openssl-src` crate and links it statically, removing the need for a system OpenSSL on any target.

`src/node/Cargo.toml` is intentionally left untouched: there is no Windows target for the `node` release workflow today.