### PR TITLE
ci(nodectl): install openssl on windows runner for release build

### DIFF
--- a/.github/workflows/nodectl-release.yml
+++ b/.github/workflows/nodectl-release.yml
@@ -46,6 +46,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y pkg-config libssl-dev
 
+      - name: Install OpenSSL (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          vcpkg install openssl:x64-windows-static-md
+          "OPENSSL_DIR=$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows-static-md" `
+            | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "OPENSSL_STATIC=1" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
       - name: Build
         working-directory: ${{ env.WORKING_DIR }}
         run: cargo build --release --package nodectl --target ${{ matrix.target }}


### PR DESCRIPTION
## Context

The Windows binary for `nodectl` failed to build in the `Publish nodectl` workflow:
https://github.com/RSquad/ton-rust-node/actions/runs/26028077294/job/76506563675

`openssl-sys v0.9.112` could not locate an OpenSSL installation on the `windows-latest` runner (no `OPENSSL_DIR`, no `VCPKG_ROOT`), while the workflow only installs `libssl-dev` on Linux.

## Change

Add a Windows-only step to `.github/workflows/nodectl-release.yml` that installs OpenSSL via vcpkg using the `x64-windows-static-md` triplet and exposes `OPENSSL_DIR` + `OPENSSL_STATIC=1` to the cargo build. Result: the resulting `nodectl.exe` is statically linked against OpenSSL (no DLL dependency for end users), and vcpkg's OpenSSL build keeps the architectural assembly paths so runtime CPU dispatch still works.

No cache is added on purpose — the Windows release runs only on tags (~once every two weeks), so the ~6 min vcpkg install is acceptable in exchange for a simpler workflow.

Other targets are untouched.