### PR TITLE
feat(nodectl): refresh past_elections cache periodically

### DIFF
--- a/src/node-control/README.md
+++ b/src/node-control/README.md
@@ -2113,7 +2113,7 @@ In service mode, nodectl runs as a daemon, automatically executing tasks on sche
 2. **Get election parameters**
    - Configuration `#15` — election time parameters
    - Configuration `#34` — current validators
-   - Query `past_elections` to the Elector contract
+   - Query `past_elections` to the Elector contract (cached per election round; see [Cache refresh](#cache-refresh) below)
 
 3. **For each enabled binding:**
    - **Stake recovery** — check and request return of frozen stake
@@ -2144,6 +2144,19 @@ Each binding resolves its effective stake policy by checking for a per-node over
 > **TONCore nominator caveat.** `Split50` and `AdaptiveSplit50` are ignored on bindings backed by a TONCore nominator — the two pools stake in different rounds, so there is nothing to split. The runner stakes the full liquid balance of the selected pool instead (still floored at `min_stake`). Use `Fixed` or `Minimum` if you need to cap per-round exposure on TONCore.
 
 > **TONCore nominator: process pending withdraws before staking.** Every tick, the elections runner probes the active TONCore pool's `has_withdraw_requests` getter. When the queue is non-empty it sends `process_withdraw_requests` (op = 2, limit = 10, message value = 1 TON) between `recover_stake` and `participate`, then skips this tick's stake submission to let the pool drain; the next tick re-probes and either resends op = 2 (new requests appeared) or proceeds to stake. This frees up locked liquidity from nominators who already requested withdrawal so it does not get re-staked. The corresponding participant status surfaced in the snapshot is `processing_withdraw_requests`. The step is a no-op for SNP and direct staking.
+
+#### Cache refresh
+
+`past_elections` and pool addresses are cached per election round (the round can run for hours, so refetching every tick is wasteful). The cache is invalidated when:
+
+- `election_id` changes (new round), **or**
+- `elections.cache_refresh_secs` seconds elapsed since the last refresh.
+
+The TTL refresh defends against a stale snapshot cached for the entire round when the initial fetch hits a lagging RPC endpoint (a real incident on mainnet caused inflated `frozen_stake` until the next round). On each refresh the runner logs `past_elections cache refreshed (reason=election_id|ttl, entries=N, election_id=...)`.
+
+| Field | Default | Notes |
+|-------|---------|-------|
+| `elections.cache_refresh_secs` | `300` (5 min) | Set to `0` to disable the time-based refresh (only `election_id` changes invalidate). Config-file only; not exposed via REST. Picked up on next file reload (≤10s). |
 
 ### Logging
 

--- a/src/node-control/common/src/app_config.rs
+++ b/src/node-control/common/src/app_config.rs
@@ -652,6 +652,10 @@ fn default_sleep_pct() -> f64 {
     0.2
 }
 
+fn default_cache_refresh_secs() -> u64 {
+    300
+}
+
 #[derive(serde::Serialize, serde::Deserialize, Clone)]
 pub struct ElectionsConfig {
     #[serde(default)]
@@ -684,6 +688,11 @@ pub struct ElectionsConfig {
     /// ephemeral ADNL address every cycle for them (pre-v0.5 behavior).
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
     pub static_adnl_disabled: HashSet<String>,
+    /// TTL (seconds) for `past_elections` and pool-address caches. `0` disables the
+    /// time-based refresh (only election_id changes invalidate). Defends against
+    /// stale snapshots cached for the whole round after a bad initial fetch.
+    #[serde(default = "default_cache_refresh_secs")]
+    pub cache_refresh_secs: u64,
 }
 
 impl ElectionsConfig {
@@ -735,6 +744,7 @@ impl Default for ElectionsConfig {
             waiting_period_pct: default_waiting_pct(),
             static_adnls: HashMap::new(),
             static_adnl_disabled: HashSet::new(),
+            cache_refresh_secs: default_cache_refresh_secs(),
         }
     }
 }

--- a/src/node-control/common/src/clock.rs
+++ b/src/node-control/common/src/clock.rs
@@ -25,7 +25,6 @@ impl Clock for SystemClock {
     }
 }
 
-/// Clones share state, so a test can advance time after handing the clock to the SUT.
 #[derive(Clone, Default)]
 pub struct MockClock {
     now: Arc<AtomicU64>,

--- a/src/node-control/common/src/clock.rs
+++ b/src/node-control/common/src/clock.rs
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2025-2026 RSquad Blockchain Lab.
+ *
+ * Licensed under the GNU General Public License v3.0.
+ * See the LICENSE file in the root of this repository.
+ *
+ * This software is provided "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ */
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
+
+/// Wall-clock abstraction. Production uses [`SystemClock`]; tests use [`MockClock`].
+pub trait Clock: Send + Sync {
+    /// Unix timestamp in seconds.
+    fn now(&self) -> u64;
+}
+
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> u64 {
+        crate::time_format::now()
+    }
+}
+
+/// Clones share state, so a test can advance time after handing the clock to the SUT.
+#[derive(Clone, Default)]
+pub struct MockClock {
+    now: Arc<AtomicU64>,
+}
+
+impl MockClock {
+    pub fn new(initial: u64) -> Self {
+        Self { now: Arc::new(AtomicU64::new(initial)) }
+    }
+
+    pub fn set(&self, t: u64) {
+        self.now.store(t, Ordering::Relaxed);
+    }
+
+    pub fn advance(&self, secs: u64) {
+        self.now.fetch_add(secs, Ordering::Relaxed);
+    }
+}
+
+impl Clock for MockClock {
+    fn now(&self) -> u64 {
+        self.now.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mock_clock_set_and_advance() {
+        let clock = MockClock::new(100);
+        assert_eq!(clock.now(), 100);
+        clock.advance(50);
+        assert_eq!(clock.now(), 150);
+        clock.set(1000);
+        assert_eq!(clock.now(), 1000);
+    }
+
+    #[test]
+    fn mock_clock_clones_share_state() {
+        let clock = MockClock::new(0);
+        let clone = clock.clone();
+        clock.set(42);
+        assert_eq!(clone.now(), 42);
+    }
+}

--- a/src/node-control/common/src/lib.rs
+++ b/src/node-control/common/src/lib.rs
@@ -8,6 +8,7 @@
  */
 pub mod app_config;
 pub mod clap_utils;
+pub mod clock;
 pub mod log;
 pub mod os_signals;
 pub mod password;

--- a/src/node-control/service/src/elections/runner.rs
+++ b/src/node-control/service/src/elections/runner.rs
@@ -14,6 +14,7 @@ use super::{
 use anyhow::Context as _;
 use common::{
     app_config::{BindingStatus, ElectionsConfig, NodeBinding, StakePolicy},
+    clock::{Clock, SystemClock},
     snapshot::{
         ElectionsParticipantSnapshot, ElectionsSnapshot, ElectionsStatus, OurElectionParticipant,
         ParticipationStatus, SnapshotStore, StakeSubmission, TimeRange, ValidatorNodeSnapshot,
@@ -251,9 +252,12 @@ pub(crate) struct ElectionRunner {
     default_max_factor: f32,
     default_stake_policy: StakePolicy,
     past_elections: Vec<PastElections>,
-    /// Election ID for which `past_elections` and `cached_prev_min_eff` were fetched.
-    /// Used to avoid redundant RPC calls within the same election round.
+    /// Election ID the cache (past_elections + pool addresses) is keyed on.
     past_elections_cache_id: u64,
+    /// Wall-clock of the last cache refresh.
+    cache_refreshed_at: u64,
+    /// Cache TTL; `0` disables the time-based refresh (only election_id changes invalidate).
+    cache_refresh_secs: u64,
     /// Cached prev_min_eff_stake computed from past_elections.
     cached_prev_min_eff: Option<u64>,
     // Snapshot cache updated during tick execution and published to SnapshotStore in run_loop().
@@ -265,6 +269,7 @@ pub(crate) struct ElectionRunner {
     /// Callback to persist freshly generated static ADNL addresses into runtime config.
     /// `None` in tests that don't care about persistence.
     persist_static_adnls: Option<PersistStaticAdnls>,
+    clock: Arc<dyn Clock>,
 }
 
 #[derive(Default)]
@@ -417,11 +422,19 @@ impl ElectionRunner {
             snapshot_cache: SnapshotCache::default(),
             past_elections: vec![],
             past_elections_cache_id: 0,
+            cache_refreshed_at: 0,
+            cache_refresh_secs: elections_config.cache_refresh_secs,
             cached_prev_min_eff: None,
             sleep_pct: elections_config.sleep_period_pct,
             waiting_pct: elections_config.waiting_period_pct,
             persist_static_adnls,
+            clock: Arc::new(SystemClock),
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_clock(&mut self, clock: Arc<dyn Clock>) {
+        self.clock = clock;
     }
 
     pub async fn run_loop(
@@ -523,21 +536,22 @@ impl ElectionRunner {
 
         let mut skip_tick_nodes = vec![];
 
-        // Pool address cache must be valid before any branch that uses `stake_addr`/`pool_target`
-        // (the finished branch below included). TONCore router pool address changes per election
-        // cycle (the router alternates between two pools), so invalidate the cache on election_id
-        // transition. SNP pool addresses are stable but invalidating uniformly is cheap.
-        // Also covers elections-task restart: `past_elections_cache_id` is 0 after start, so the
-        // first tick lands here and re-resolves.
-        if self.past_elections_cache_id != election_id {
+        // TTL refresh defends against stale snapshots cached for the whole round when the
+        // initial fetch hit a lagging RPC endpoint. TONCore pool address alternates per
+        // cycle, so uniform invalidation is required.
+        let now_ts = self.clock.now();
+        let cache_expired = self.cache_refresh_secs > 0
+            && now_ts.saturating_sub(self.cache_refreshed_at) >= self.cache_refresh_secs;
+        let should_refresh_cache = self.past_elections_cache_id != election_id || cache_expired;
+        if should_refresh_cache {
             for node in self.nodes.values_mut() {
                 if node.pool.is_some() {
                     node.pool_addr_cache = None;
                 }
             }
         }
-        // Resolve pool address for any node where it isn't cached yet. On election_id transition
-        // the cache was just invalidated above; on other ticks this recovers from a transient
+        // Resolve pool address for any node where it isn't cached yet. On cache invalidation
+        // the cache was just cleared above; on other ticks this recovers from a transient
         // `pool.address()` failure (e.g. a `get_pool_data` parse error on TONCore).
         for (node_id, node) in self.nodes.iter_mut() {
             Self::resolve_pool_addr(node_id, node, &mut skip_tick_nodes).await;
@@ -578,14 +592,20 @@ impl ElectionRunner {
             self.snapshot_cache.last_elections_status = ElectionsStatus::Postponed;
         }
 
-        // Fetch past_elections only when election_id changes (cache across ticks).
-        if self.past_elections_cache_id != election_id {
+        if should_refresh_cache {
+            let reason =
+                if self.past_elections_cache_id != election_id { "election_id" } else { "ttl" };
             self.past_elections = self.elector.past_elections().await.context("past_elections")?;
             self.cached_prev_min_eff = self
                 .past_elections
                 .first()
                 .and_then(|pe| pe.frozen_map.values().min_by_key(|f| f.stake).map(|f| f.stake));
-
+            tracing::info!(
+                "past_elections cache refreshed (reason={}, entries={}, election_id={})",
+                reason,
+                self.past_elections.len(),
+                election_id
+            );
             if let Some(prev) = self.cached_prev_min_eff {
                 tracing::info!(
                     "prev_min_eff_stake from past elections: {} TON",
@@ -593,6 +613,7 @@ impl ElectionRunner {
                 );
             }
             self.past_elections_cache_id = election_id;
+            self.cache_refreshed_at = now_ts;
         }
 
         // walk through the nodes and try to participate in the elections

--- a/src/node-control/service/src/elections/runner.rs
+++ b/src/node-control/service/src/elections/runner.rs
@@ -254,7 +254,7 @@ pub(crate) struct ElectionRunner {
     past_elections: Vec<PastElections>,
     /// Election ID the cache (past_elections + pool addresses) is keyed on.
     past_elections_cache_id: u64,
-    /// Wall-clock of the last cache refresh.
+    /// Unix timestamp of the last cache refresh.
     cache_refreshed_at: u64,
     /// Cache TTL; `0` disables the time-based refresh (only election_id changes invalidate).
     cache_refresh_secs: u64,
@@ -536,9 +536,6 @@ impl ElectionRunner {
 
         let mut skip_tick_nodes = vec![];
 
-        // TTL refresh defends against stale snapshots cached for the whole round when the
-        // initial fetch hit a lagging RPC endpoint. TONCore pool address alternates per
-        // cycle, so uniform invalidation is required.
         let now_ts = self.clock.now();
         let cache_expired = self.cache_refresh_secs > 0
             && now_ts.saturating_sub(self.cache_refreshed_at) >= self.cache_refresh_secs;
@@ -601,7 +598,7 @@ impl ElectionRunner {
                 .first()
                 .and_then(|pe| pe.frozen_map.values().min_by_key(|f| f.stake).map(|f| f.stake));
             tracing::info!(
-                "past_elections cache refreshed (reason={}, entries={}, election_id={})",
+                "past_elections cache refreshed: reason={}, entries={}, election_id={}",
                 reason,
                 self.past_elections.len(),
                 election_id

--- a/src/node-control/service/src/elections/runner_tests.rs
+++ b/src/node-control/service/src/elections/runner_tests.rs
@@ -9,6 +9,7 @@
 use super::*;
 use common::{
     app_config::{ElectionsConfig, NodeBinding, StakePolicy},
+    clock::MockClock,
     snapshot::SnapshotStore,
     task_cancellation::{CancellationCtx, CancellationReason},
     time_format,
@@ -396,6 +397,7 @@ impl TestHarness {
                 waiting_period_pct: 0.3,
                 static_adnls: HashMap::new(),
                 static_adnl_disabled: HashSet::new(),
+                cache_refresh_secs: 300,
             },
             bindings: HashMap::new(),
             persisted_static_adnls: None,
@@ -1335,6 +1337,7 @@ async fn test_multiple_nodes_one_excluded() {
         waiting_period_pct: 0.3,
         static_adnls: HashMap::new(),
         static_adnl_disabled: HashSet::from(["node-1".to_string(), "node-2".to_string()]),
+        cache_refresh_secs: 300,
     };
 
     let mut bindings = HashMap::new();
@@ -1775,6 +1778,7 @@ async fn test_node_without_wallet_skipped() {
         waiting_period_pct: 0.3,
         static_adnls: HashMap::new(),
         static_adnl_disabled: HashSet::new(),
+        cache_refresh_secs: 300,
     };
 
     let mut bindings = HashMap::new();
@@ -3533,4 +3537,184 @@ async fn test_static_adnl_generation_failure_aborts_node_only() {
     assert!(node.participant.is_none(), "no participant when ADNL generation failed");
     let saved = persisted.lock().unwrap();
     assert!(saved.is_empty(), "nothing should be persisted on failure");
+}
+
+// =====================================================
+// TTL-based cache refresh (SMA-98)
+// =====================================================
+
+/// Like `setup_default_elector` but asserts an exact `past_elections()` call count.
+fn setup_elector_with_past_elections_times(
+    elector: &mut MockElectorWrapperImpl,
+    election_id: u64,
+    times: usize,
+) {
+    elector.expect_address().returning(|| Ok(elector_address()));
+    elector.expect_get_active_election_id().returning(move || Ok(election_id));
+    elector.expect_elections_info().returning(move || {
+        Ok(ElectionsInfo {
+            election_id,
+            elect_close: election_id - 300,
+            min_stake: MIN_STAKE,
+            total_stake: 0,
+            failed: false,
+            finished: false,
+            participants: vec![],
+        })
+    });
+    elector.expect_past_elections().times(times).returning(|| Ok(vec![]));
+    elector.expect_compute_returned_stake().returning(|_addr| Ok(0));
+}
+
+#[tokio::test]
+async fn cache_refetched_after_ttl_within_same_election() {
+    let node_id = "node-1";
+    let mut harness = TestHarness::new();
+    harness.elections_config.cache_refresh_secs = 60;
+
+    // Two ticks at the same election_id; TTL elapses between them → past_elections() twice.
+    setup_elector_with_past_elections_times(&mut harness.elector_mock, ELECTION_ID, 2);
+    setup_default_provider(&mut harness.provider_mock, WALLET_BALANCE, None);
+    setup_wallet(&mut harness.wallet_mock);
+
+    let mut runner = harness.build(node_id).await;
+    let clock = MockClock::new(1_000);
+    runner.set_clock(Arc::new(clock.clone()));
+
+    let _ = runner.run().await;
+    clock.advance(61);
+    let _ = runner.run().await;
+}
+
+#[tokio::test]
+async fn cache_not_refetched_before_ttl() {
+    let node_id = "node-1";
+    let mut harness = TestHarness::new();
+    harness.elections_config.cache_refresh_secs = 60;
+
+    setup_elector_with_past_elections_times(&mut harness.elector_mock, ELECTION_ID, 1);
+    setup_default_provider(&mut harness.provider_mock, WALLET_BALANCE, None);
+    setup_wallet(&mut harness.wallet_mock);
+
+    let mut runner = harness.build(node_id).await;
+    let clock = MockClock::new(1_000);
+    runner.set_clock(Arc::new(clock.clone()));
+
+    let _ = runner.run().await;
+    clock.advance(30);
+    let _ = runner.run().await;
+}
+
+#[tokio::test]
+async fn cache_refresh_disabled_when_ttl_zero() {
+    let node_id = "node-1";
+    let mut harness = TestHarness::new();
+    harness.elections_config.cache_refresh_secs = 0;
+
+    // Even with a huge clock jump the cache must not be refetched while election_id is stable.
+    setup_elector_with_past_elections_times(&mut harness.elector_mock, ELECTION_ID, 1);
+    setup_default_provider(&mut harness.provider_mock, WALLET_BALANCE, None);
+    setup_wallet(&mut harness.wallet_mock);
+
+    let mut runner = harness.build(node_id).await;
+    let clock = MockClock::new(1_000);
+    runner.set_clock(Arc::new(clock.clone()));
+
+    let _ = runner.run().await;
+    clock.advance(86_400);
+    let _ = runner.run().await;
+}
+
+#[tokio::test]
+async fn ttl_refresh_invalidates_pool_address_cache() {
+    let node_id = "node-1";
+    let mut harness = TestHarness::new().with_pool();
+    harness.elections_config.cache_refresh_secs = 60;
+
+    setup_elector_with_past_elections_times(&mut harness.elector_mock, ELECTION_ID, 2);
+    setup_default_provider(&mut harness.provider_mock, WALLET_BALANCE, Some(POOL_BALANCE));
+    setup_wallet(&mut harness.wallet_mock);
+
+    // Pool::address() must be queried again after TTL refresh — twice across two ticks.
+    let pool = harness.pool_mock.as_mut().unwrap();
+    pool.expect_address().times(2).returning(|| Ok(pool_address()));
+    pool.expect_inner_pools().returning(|| vec![]);
+    pool.expect_storage_reserve().returning(|| SNP_STORAGE_RESERVE);
+    pool.expect_pool_kind().returning(|| PoolKind::SNP);
+    pool.expect_has_withdraw_requests().returning(|| Ok(false));
+
+    let mut runner = harness.build(node_id).await;
+    let clock = MockClock::new(1_000);
+    runner.set_clock(Arc::new(clock.clone()));
+
+    let _ = runner.run().await;
+    assert!(runner.nodes.get(node_id).unwrap().pool_addr_cache.is_some());
+
+    clock.advance(61);
+    let _ = runner.run().await;
+    assert!(
+        runner.nodes.get(node_id).unwrap().pool_addr_cache.is_some(),
+        "pool address must be re-resolved after TTL expiry"
+    );
+}
+
+#[tokio::test]
+async fn cached_prev_min_eff_updates_on_refresh() {
+    let node_id = "node-1";
+    let mut harness = TestHarness::new();
+    harness.elections_config.cache_refresh_secs = 60;
+
+    harness.elector_mock.expect_address().returning(|| Ok(elector_address()));
+    harness.elector_mock.expect_get_active_election_id().returning(|| Ok(ELECTION_ID));
+    harness.elector_mock.expect_elections_info().returning(|| {
+        Ok(ElectionsInfo {
+            election_id: ELECTION_ID,
+            elect_close: ELECTION_ID - 300,
+            min_stake: MIN_STAKE,
+            total_stake: 0,
+            failed: false,
+            finished: false,
+            participants: vec![],
+        })
+    });
+    harness.elector_mock.expect_compute_returned_stake().returning(|_addr| Ok(0));
+
+    let call_idx = Arc::new(std::sync::atomic::AtomicU32::new(0));
+    let call_idx_for_mock = call_idx.clone();
+    harness.elector_mock.expect_past_elections().times(2).returning(move || {
+        let n = call_idx_for_mock.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let stake = if n == 0 { 100_000 * NANO } else { 50_000 * NANO };
+        let mut frozen_map = HashMap::new();
+        frozen_map.insert(
+            [0xAA; 32],
+            FrozenParticipant { wallet_addr: [0xBB; 32], weight: 1, stake, banned: false },
+        );
+        Ok(vec![PastElections {
+            election_id: ELECTION_ID - 3600,
+            unfreeze_at: ELECTION_ID,
+            stake_held: 7200,
+            vset_hash: vec![],
+            frozen_map,
+            total_stake: stake,
+            bonuses: 0,
+        }])
+    });
+
+    setup_default_provider(&mut harness.provider_mock, WALLET_BALANCE, None);
+    setup_wallet(&mut harness.wallet_mock);
+
+    let mut runner = harness.build(node_id).await;
+    let clock = MockClock::new(1_000);
+    runner.set_clock(Arc::new(clock.clone()));
+
+    let _ = runner.run().await;
+    assert_eq!(runner.cached_prev_min_eff, Some(100_000 * NANO));
+
+    clock.advance(61);
+    let _ = runner.run().await;
+    assert_eq!(
+        runner.cached_prev_min_eff,
+        Some(50_000 * NANO),
+        "cached_prev_min_eff must reflect the refreshed past_elections snapshot"
+    );
 }

--- a/src/node/tests/test_run_net_py/run_singlehost_nodectl.py
+++ b/src/node/tests/test_run_net_py/run_singlehost_nodectl.py
@@ -934,6 +934,13 @@ class Bootstrap:
         self.log.info("  config generate...")
         self._nctl("config", "generate", "--output", str(self.paths.nodectl_config), "--force")
 
+        # Short past_elections cache TTL so e2e can observe periodic refresh in the logs
+        # (search for `past_elections cache refreshed (reason=ttl, ...)`).
+        cfg_json = json.loads(self.paths.nodectl_config.read_text())
+        cfg_json.setdefault("elections", {})["cache_refresh_secs"] = 60
+        self.paths.nodectl_config.write_text(json.dumps(cfg_json, indent=2))
+        self.log.info("  elections.cache_refresh_secs → 60")
+
         # Create the key used by nodes 3+ (nodes 1-2 get per-node keys in phase 6)
         self.log.info("  key add control-client-secret...")
         self._nctl("key", "add", "-n", "control-client-secret", "-e")


### PR DESCRIPTION
## Summary

- Adds a TTL-based refresh for the elections runner's `past_elections` and pool-address caches (currently invalidated only on `election_id` change).
- Defends against the SMA-98 incident where a stale snapshot from a lagging RPC endpoint persisted for the whole round and inflated `frozen_stake` to 2× the real value.
- New config field `elections.cache_refresh_secs` (default `300`, set `0` to disable). Hot-reloaded via the 10s config-file watch.
- `Clock` trait introduced in `common` (production `SystemClock`, deterministic `MockClock`) so the TTL logic is unit-testable without real-time sleeps.
- Singlehost e2e (`run_singlehost_nodectl.py`) sets `cache_refresh_secs=60` after `config generate` so the periodic refresh is exercised in the e2e log.

Closes SMA-98.