### PR TITLE
feat(nodectl): detect lagging JSON-RPC endpoints via masterchain freshness probe

### DIFF
--- a/src/node-control/README.md
+++ b/src/node-control/README.md
@@ -529,6 +529,17 @@ nodectl config ton-http-api add \
   --endpoint "https://backup2.example/api/v2/jsonRpc"
 ```
 
+##### Freshness probing
+
+Before each request the client lazily probes every endpoint it is about to use to verify it isn't lagging behind the chain. The probe runs `getMasterchainInfo` + `getBlockHeader`, then compares the block's `gen_utime` against wall-clock time. Endpoints whose chain view exceeds `freshness_max_lag_secs` are skipped; if **every** endpoint is stale the client returns a dedicated error (`is_endpoints_stale(err) == true`) instead of silently serving stale data.
+
+The probe is rate-limited: each endpoint is re-probed at most once per `freshness_probe_interval_secs`. Both values live under `ton_http_api` in the config file and there is no CLI command for them — edit the JSON directly. They are hot-reloaded with the rest of the config (file watch interval ≤10s).
+
+| Field | Default | Notes |
+|-------|---------|-------|
+| `ton_http_api.freshness_probe_interval_secs` | `30` | How often (seconds) the freshness probe runs per endpoint. |
+| `ton_http_api.freshness_max_lag_secs` | `60` | Maximum tolerated chain-tip lag (seconds) before the endpoint is treated as stale. |
+
 ---
 
 #### `config master-wallet`

--- a/src/node-control/commands/src/commands/nodectl/utils.rs
+++ b/src/node-control/commands/src/commands/nodectl/utils.rs
@@ -217,6 +217,7 @@ pub async fn load_config_vault_rpc_client(
             config.ton_http_api.resolved_endpoints(),
             config.ton_http_api.api_key.clone(),
             config.ton_http_api.resolved_timeouts(),
+            config.ton_http_api.resolved_freshness(),
         )
         .context("ClientJsonRpc")?,
     );

--- a/src/node-control/commands/src/commands/ton_http_api/get_config_param_cmd.rs
+++ b/src/node-control/commands/src/commands/ton_http_api/get_config_param_cmd.rs
@@ -41,6 +41,7 @@ impl GetConfigParamCmd {
             app_cfg.ton_http_api.resolved_endpoints(),
             app_cfg.ton_http_api.api_key.clone(),
             app_cfg.ton_http_api.resolved_timeouts(),
+            app_cfg.ton_http_api.resolved_freshness(),
         )?;
 
         let config = rpc_client

--- a/src/node-control/common/src/app_config.rs
+++ b/src/node-control/common/src/app_config.rs
@@ -37,6 +37,39 @@ fn default_ton_http_api_url() -> String {
 pub const DEFAULT_TON_HTTP_API_CONNECT_TIMEOUT_SECS: u64 = 3;
 /// Default per-endpoint request timeout for ton-http-api calls (seconds).
 pub const DEFAULT_TON_HTTP_API_REQUEST_TIMEOUT_SECS: u64 = 5;
+/// Default interval (seconds) between freshness probes for a single endpoint.
+pub const DEFAULT_FRESHNESS_PROBE_INTERVAL_SECS: u64 = 30;
+/// Default maximum masterchain block gen_utime lag (seconds) tolerated before an endpoint is treated as stale.
+pub const DEFAULT_FRESHNESS_MAX_LAG_SECS: u64 = 60;
+
+/// Per-endpoint freshness policy for the ton-http-api JSON-RPC client.
+#[derive(Copy, Clone, Debug)]
+pub struct FreshnessConfig {
+    /// Controls how often the client probes an endpoint's masterchain block
+    pub probe_interval_secs: u64,
+    /// Absolute age (now - block gen_utime) above which the endpoint is
+    /// considered stale and skipped.
+    pub max_lag_secs: u64,
+}
+
+impl Default for FreshnessConfig {
+    fn default() -> Self {
+        Self {
+            probe_interval_secs: DEFAULT_FRESHNESS_PROBE_INTERVAL_SECS,
+            max_lag_secs: DEFAULT_FRESHNESS_MAX_LAG_SECS,
+        }
+    }
+}
+
+impl FreshnessConfig {
+    /// Effectively disables probing: the probe interval never elapses and the lag
+    /// threshold is unreachable. Used in tests and code paths that must not depend
+    /// on `getMasterchainInfo`/`getBlockHeader` (e.g. lightweight CLI commands).
+    #[must_use]
+    pub fn disabled() -> Self {
+        Self { probe_interval_secs: u64::MAX, max_lag_secs: u64::MAX }
+    }
+}
 
 /// Resolved per-endpoint timeouts for the ton-http-api JSON-RPC client.
 ///
@@ -121,6 +154,14 @@ pub struct TonHttpApiConfig {
     /// Defaults to [`DEFAULT_TON_HTTP_API_REQUEST_TIMEOUT_SECS`] when unset.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub request_timeout_secs: Option<u64>,
+    /// Interval (seconds) between freshness probes per endpoint.
+    /// Defaults to [`DEFAULT_FRESHNESS_PROBE_INTERVAL_SECS`] when unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub freshness_probe_interval_secs: Option<u64>,
+    /// Maximum masterchain gen_utime lag (seconds) before an endpoint is treated as stale.
+    /// Defaults to [`DEFAULT_FRESHNESS_MAX_LAG_SECS`] when unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub freshness_max_lag_secs: Option<u64>,
 }
 
 impl Default for TonHttpApiConfig {
@@ -131,6 +172,8 @@ impl Default for TonHttpApiConfig {
             api_key: None,
             connect_timeout_secs: None,
             request_timeout_secs: None,
+            freshness_probe_interval_secs: None,
+            freshness_max_lag_secs: None,
         }
     }
 }
@@ -193,6 +236,17 @@ impl TonHttpApiConfig {
             request: Duration::from_secs(
                 self.request_timeout_secs.unwrap_or(DEFAULT_TON_HTTP_API_REQUEST_TIMEOUT_SECS),
             ),
+        }
+    }
+
+    /// Returns the resolved freshness policy, filling in defaults for unset fields.
+    #[must_use]
+    pub fn resolved_freshness(&self) -> FreshnessConfig {
+        FreshnessConfig {
+            probe_interval_secs: self
+                .freshness_probe_interval_secs
+                .unwrap_or(DEFAULT_FRESHNESS_PROBE_INTERVAL_SECS),
+            max_lag_secs: self.freshness_max_lag_secs.unwrap_or(DEFAULT_FRESHNESS_MAX_LAG_SECS),
         }
     }
 }

--- a/src/node-control/common/src/clock.rs
+++ b/src/node-control/common/src/clock.rs
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2025-2026 RSquad Blockchain Lab.
+ *
+ * Licensed under the GNU General Public License v3.0.
+ * See the LICENSE file in the root of this repository.
+ *
+ * This software is provided "AS IS", WITHOUT WARRANTY OF ANY KIND.
+ */
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
+
+/// Wall-clock abstraction. Production uses [`SystemClock`]; tests use [`MockClock`].
+pub trait Clock: Send + Sync {
+    /// Unix timestamp in seconds.
+    fn now(&self) -> u64;
+}
+
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> u64 {
+        crate::time_format::now()
+    }
+}
+
+/// Clones share state, so a test can advance time after handing the clock to the SUT.
+#[derive(Clone, Default)]
+pub struct MockClock {
+    now: Arc<AtomicU64>,
+}
+
+impl MockClock {
+    pub fn new(initial: u64) -> Self {
+        Self { now: Arc::new(AtomicU64::new(initial)) }
+    }
+
+    pub fn set(&self, t: u64) {
+        self.now.store(t, Ordering::Relaxed);
+    }
+
+    pub fn advance(&self, secs: u64) {
+        self.now.fetch_add(secs, Ordering::Relaxed);
+    }
+}
+
+impl Clock for MockClock {
+    fn now(&self) -> u64 {
+        self.now.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mock_clock_set_and_advance() {
+        let clock = MockClock::new(100);
+        assert_eq!(clock.now(), 100);
+        clock.advance(50);
+        assert_eq!(clock.now(), 150);
+        clock.set(1000);
+        assert_eq!(clock.now(), 1000);
+    }
+
+    #[test]
+    fn mock_clock_clones_share_state() {
+        let clock = MockClock::new(0);
+        let clone = clock.clone();
+        clock.set(42);
+        assert_eq!(clone.now(), 42);
+    }
+}

--- a/src/node-control/common/src/lib.rs
+++ b/src/node-control/common/src/lib.rs
@@ -8,6 +8,7 @@
  */
 pub mod app_config;
 pub mod clap_utils;
+pub mod clock;
 pub mod log;
 pub mod os_signals;
 pub mod password;

--- a/src/node-control/service/src/auth/user_store.rs
+++ b/src/node-control/service/src/auth/user_store.rs
@@ -389,6 +389,7 @@ mod tests {
                     vec![("http://127.0.0.1:3301/".to_owned(), None)],
                     None,
                     common::app_config::EndpointTimeouts::default(),
+                    common::app_config::FreshnessConfig::disabled(),
                 )
                 .unwrap(),
             )

--- a/src/node-control/service/src/contracts/contracts_task.rs
+++ b/src/node-control/service/src/contracts/contracts_task.rs
@@ -799,7 +799,15 @@ mod tests {
         master_wallet: Arc<dyn TonWallet>,
         wallets: Arc<HashMap<String, Arc<dyn TonWallet>>>,
     ) -> ContractsMonitor {
-        let rpc_client = Arc::new(ClientJsonRpc::connect(rpc_url, None).unwrap());
+        let rpc_client = Arc::new(
+            ClientJsonRpc::connect_many(
+                vec![(rpc_url, None)],
+                None,
+                common::app_config::EndpointTimeouts::default(),
+                common::app_config::FreshnessConfig::disabled(),
+            )
+            .unwrap(),
+        );
         ContractsMonitor {
             master_wallet,
             pools: Arc::<HashMap<String, Arc<dyn NominatorWrapper>>>::default(),

--- a/src/node-control/service/src/runtime_config.rs
+++ b/src/node-control/service/src/runtime_config.rs
@@ -243,6 +243,7 @@ impl RuntimeConfigStore {
                 app_config.ton_http_api.resolved_endpoints(),
                 app_config.ton_http_api.api_key.clone(),
                 app_config.ton_http_api.resolved_timeouts(),
+                app_config.ton_http_api.resolved_freshness(),
             )
             .unwrap(),
         );
@@ -462,6 +463,7 @@ impl RuntimeConfigStore {
                 resolved.clone(),
                 app_cfg.ton_http_api.api_key.clone(),
                 app_cfg.ton_http_api.resolved_timeouts(),
+                app_cfg.ton_http_api.resolved_freshness(),
             )
             .context("ton api connection error")?,
         );

--- a/src/node-control/ton-http-api-client/src/v2/client_json_rpc.rs
+++ b/src/node-control/ton-http-api-client/src/v2/client_json_rpc.rs
@@ -171,7 +171,11 @@ impl ClientJsonRpc {
     ///    refreshed lazily (probe = `getMasterchainInfo` + `getBlockHeader`,
     ///    rate-limited by `freshness_cfg.probe_interval_secs`). Endpoints whose
     ///    masterchain block view is older than `freshness_cfg.max_lag_secs`
-    ///    are skipped. Each attempt is bounded by [`EndpointTimeouts::total`].
+    ///    are skipped. Each individual RPC (probe call or business call) is
+    ///    bounded by [`EndpointTimeouts::total`]; when a probe runs, an attempt
+    ///    may therefore consume up to ~3× that budget (2 probe RPCs + 1
+    ///    business RPC). Once an endpoint is known fresh (probe within TTL),
+    ///    only the business RPC runs and the attempt is bounded by 1× budget.
     /// 3. On success the response is returned immediately. On total failure
     ///    the error is `ENDPOINTS_STALE_TAG` when every endpoint was skipped
     ///    because of staleness, otherwise `ENDPOINTS_UNREACHABLE_TAG`.
@@ -290,8 +294,12 @@ impl ClientJsonRpc {
     /// `observed_at == 0` (never probed) is intentionally treated as fresh: probe failures
     /// are handled by the caller (`json_rpc` continues to the next endpoint), so this branch
     /// only fires when probing is disabled via [`FreshnessConfig::disabled`].
+    ///
+    /// The `Acquire` load of `observed_at` pairs with the `Release` store in
+    /// [`Self::refresh_endpoint_freshness`] so the matching `gen_utime` is guaranteed to be
+    /// the one published alongside this `observed_at` value (no torn snapshot).
     fn is_endpoint_stale(&self, idx: usize) -> bool {
-        let observed_at = self.endpoints[idx].freshness.observed_at.load(Ordering::Relaxed);
+        let observed_at = self.endpoints[idx].freshness.observed_at.load(Ordering::Acquire);
         if observed_at == 0 {
             return false;
         }
@@ -331,8 +339,10 @@ impl ClientJsonRpc {
 
         let now = self.clock.now();
         let endpoint = &self.endpoints[idx];
+        // Publish gen_utime first, then observed_at with Release so an Acquire reader of
+        // observed_at sees the matching gen_utime (no torn snapshot).
         endpoint.freshness.gen_utime.store(header.gen_utime, Ordering::Relaxed);
-        endpoint.freshness.observed_at.store(now, Ordering::Relaxed);
+        endpoint.freshness.observed_at.store(now, Ordering::Release);
         Ok(())
     }
 

--- a/src/node-control/ton-http-api-client/src/v2/client_json_rpc.rs
+++ b/src/node-control/ton-http-api-client/src/v2/client_json_rpc.rs
@@ -7,15 +7,21 @@
  * This software is provided "AS IS", WITHOUT WARRANTY OF ANY KIND.
  */
 use crate::v2::data_models::{
-    GetAddressInformationRes, GetExtendedAddressInformationRes, GetWalletInformationRes,
-    RunGetMethodParams, RunGetMethodRes,
+    BlockIdExt, GetAddressInformationRes, GetBlockHeaderRes, GetExtendedAddressInformationRes,
+    GetMasterchainInfoRes, GetWalletInformationRes, RunGetMethodParams, RunGetMethodRes,
 };
 use anyhow::Context;
 use base64::Engine;
-use common::app_config::EndpointTimeouts;
+use common::{
+    app_config::{EndpointTimeouts, FreshnessConfig},
+    clock::{Clock, SystemClock},
+};
 use std::{
     collections::HashSet,
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::{
+        Arc,
+        atomic::{AtomicU32, AtomicU64, AtomicUsize, Ordering},
+    },
 };
 use ton_block::{ConfigParamEnum, MsgAddressInt, read_boc};
 use toncenter_rs::client::{
@@ -26,27 +32,52 @@ use toncenter_rs::client::{
 /// should use [`is_endpoints_unreachable`] rather than matching on it directly.
 pub const ENDPOINTS_UNREACHABLE_TAG: &str = "ton-http-api unreachable";
 
+/// Marker embedded in the "all endpoints serving stale chain data" error.
+/// Use [`is_endpoints_stale`] rather than matching on it directly.
+pub const ENDPOINTS_STALE_TAG: &str = "ton-http-api stale";
+
 /// `true` if `err` (or any source in its chain) is the aggregated
 /// "all endpoints failed" error from [`ClientJsonRpc::json_rpc`].
 pub fn is_endpoints_unreachable(err: &anyhow::Error) -> bool {
     err.chain().any(|c| c.to_string().contains(ENDPOINTS_UNREACHABLE_TAG))
 }
 
+/// `true` if `err` is the "all endpoints stale" error from [`ClientJsonRpc::json_rpc`].
+pub fn is_endpoints_stale(err: &anyhow::Error) -> bool {
+    err.chain().any(|c| c.to_string().contains(ENDPOINTS_STALE_TAG))
+}
+
+/// Cached freshness signal for an endpoint, populated by lazy probes.
+/// `observed_at == 0` means never probed successfully.
+#[derive(Default)]
+struct EndpointFreshness {
+    gen_utime: AtomicU32,
+    observed_at: AtomicU64,
+}
+
 struct EndpointClient {
     url: String,
     client: TonApiClientV2,
+    freshness: EndpointFreshness,
 }
 
 pub struct ClientJsonRpc {
     api_key: Option<String>,
     endpoints: Vec<EndpointClient>,
     timeouts: EndpointTimeouts,
+    freshness_cfg: FreshnessConfig,
+    clock: Arc<dyn Clock>,
     rr_cursor: AtomicUsize,
 }
 
 impl ClientJsonRpc {
     pub fn connect(url: String, api_key: Option<String>) -> anyhow::Result<Self> {
-        Self::connect_many(vec![(url, None)], api_key, EndpointTimeouts::default())
+        Self::connect_many(
+            vec![(url, None)],
+            api_key,
+            EndpointTimeouts::default(),
+            FreshnessConfig::default(),
+        )
     }
 
     /// Builds a failover client from one or more endpoint entries.
@@ -58,6 +89,9 @@ impl ClientJsonRpc {
     /// unreachable ton-http-api cannot stall the daemon: each call is
     /// wrapped in [`tokio::time::timeout`] with budget [`EndpointTimeouts::total`].
     ///
+    /// `freshness` governs the lazy `getMasterchainInfo` + `getBlockHeader`
+    /// probe that detects endpoints serving stale chain data.
+    ///
     /// This constructor is defensive: it trims inputs, drops empty values and
     /// deduplicates URLs while preserving order. Callers should normally pass
     /// pre-normalized values from `TonHttpApiConfig::resolved_endpoints()`,
@@ -66,6 +100,7 @@ impl ClientJsonRpc {
         entries: Vec<(String, Option<String>)>,
         default_api_key: Option<String>,
         timeouts: EndpointTimeouts,
+        freshness_cfg: FreshnessConfig,
     ) -> anyhow::Result<Self> {
         let mut seen = HashSet::with_capacity(entries.len());
         let mut unique: Vec<(String, Option<String>)> = Vec::with_capacity(entries.len());
@@ -94,6 +129,7 @@ impl ClientJsonRpc {
                         effective_key.map(|v| TonApiKey::Header(v.to_string())),
                     ),
                     url,
+                    freshness: EndpointFreshness::default(),
                 }
             })
             .collect::<Vec<_>>();
@@ -102,8 +138,15 @@ impl ClientJsonRpc {
             api_key: default_api_key,
             endpoints,
             timeouts,
+            freshness_cfg,
+            clock: Arc::new(SystemClock),
             rr_cursor: AtomicUsize::new(0),
         })
+    }
+
+    #[cfg(test)]
+    pub fn set_clock(&mut self, clock: Arc<dyn Clock>) {
+        self.clock = clock;
     }
 
     pub fn api_key(&self) -> Option<String> {
@@ -124,13 +167,14 @@ impl ClientJsonRpc {
     /// 1. An atomic cursor picks a per-request start endpoint so that
     ///    successive calls are spread across endpoints in round-robin order.
     /// 2. Starting from that endpoint, each endpoint is tried once in
-    ///    cyclic order until one succeeds or all have been exhausted.
-    ///    Each per-endpoint attempt is bounded by [`EndpointTimeouts::total`]
-    ///    so an unreachable upstream cannot stall the failover loop.
-    /// 3. On success the response is returned immediately; on total failure
-    ///    an aggregated error is returned listing every attempted endpoint
-    ///    with its failure reason so the operator can identify ton-http-api
-    ///    as the source.
+    ///    cyclic order. Before each attempt the endpoint's freshness is
+    ///    refreshed lazily (probe = `getMasterchainInfo` + `getBlockHeader`,
+    ///    rate-limited by `freshness_cfg.probe_interval_secs`). Endpoints whose
+    ///    masterchain block view is older than `freshness_cfg.max_lag_secs`
+    ///    are skipped. Each attempt is bounded by [`EndpointTimeouts::total`].
+    /// 3. On success the response is returned immediately. On total failure
+    ///    the error is `ENDPOINTS_STALE_TAG` when every endpoint was skipped
+    ///    because of staleness, otherwise `ENDPOINTS_UNREACHABLE_TAG`.
     async fn json_rpc(
         &self,
         method: &'static str,
@@ -141,10 +185,37 @@ impl ClientJsonRpc {
         let request_id = serde_json::json!(uuid::Uuid::new_v4().to_string());
         let per_endpoint_budget = self.timeouts.total();
         let mut failures: Vec<(String, String)> = Vec::with_capacity(total);
+        let mut stale_count: usize = 0;
 
         for attempt in 0..total {
             let idx = (start + attempt) % total;
             let endpoint = &self.endpoints[idx];
+
+            if self.needs_freshness_refresh(idx)
+                && let Err(e) = self.refresh_endpoint_freshness(idx).await
+            {
+                tracing::debug!(
+                    method,
+                    endpoint = %endpoint.url,
+                    attempt = attempt + 1,
+                    error = %e,
+                    "ton-http-api freshness probe failed"
+                );
+                failures.push((endpoint.url.clone(), format!("freshness probe failed: {e}")));
+                continue;
+            }
+            if self.is_endpoint_stale(idx) {
+                stale_count += 1;
+                tracing::debug!(
+                    method,
+                    endpoint = %endpoint.url,
+                    attempt = attempt + 1,
+                    "ton-http-api endpoint is stale, skipping"
+                );
+                failures.push((endpoint.url.clone(), "stale chain view".to_string()));
+                continue;
+            }
+
             let call = endpoint.client.json_rpc(method, params.clone(), request_id.clone());
             match tokio::time::timeout(per_endpoint_budget, call).await {
                 Ok(Ok(response)) => {
@@ -190,6 +261,17 @@ impl ClientJsonRpc {
             .map(|(url, reason)| format!("{}: {}", url, reason))
             .collect::<Vec<_>>()
             .join("; ");
+
+        if stale_count == total {
+            tracing::warn!(
+                method,
+                total_attempts = total,
+                failures = %detail,
+                "ton-http-api all endpoints serving stale chain data"
+            );
+            anyhow::bail!("{}: all {} endpoint(s) stale: [{}]", ENDPOINTS_STALE_TAG, total, detail);
+        }
+
         tracing::warn!(
             method,
             total_attempts = total,
@@ -197,6 +279,61 @@ impl ClientJsonRpc {
             "ton-http-api unreachable on all endpoints"
         );
         anyhow::bail!("{}: tried {} endpoint(s): [{}]", ENDPOINTS_UNREACHABLE_TAG, total, detail)
+    }
+
+    /// `true` when the cached freshness is older than the configured probe interval.
+    fn needs_freshness_refresh(&self, idx: usize) -> bool {
+        let observed_at = self.endpoints[idx].freshness.observed_at.load(Ordering::Relaxed);
+        self.clock.now().saturating_sub(observed_at) >= self.freshness_cfg.probe_interval_secs
+    }
+
+    /// `observed_at == 0` (never probed) is intentionally treated as fresh: probe failures
+    /// are handled by the caller (`json_rpc` continues to the next endpoint), so this branch
+    /// only fires when probing is disabled via [`FreshnessConfig::disabled`].
+    fn is_endpoint_stale(&self, idx: usize) -> bool {
+        let observed_at = self.endpoints[idx].freshness.observed_at.load(Ordering::Relaxed);
+        if observed_at == 0 {
+            return false;
+        }
+        let gen_utime = self.endpoints[idx].freshness.gen_utime.load(Ordering::Relaxed);
+        self.clock.now().saturating_sub(u64::from(gen_utime)) > self.freshness_cfg.max_lag_secs
+    }
+
+    /// Invoke a JSON-RPC method on a single endpoint (no failover), parse the result into `T`.
+    async fn call_single_endpoint<T: serde::de::DeserializeOwned>(
+        &self,
+        idx: usize,
+        method: &'static str,
+        params: serde_json::Value,
+    ) -> anyhow::Result<T> {
+        let endpoint = &self.endpoints[idx];
+        let budget = self.timeouts.total();
+        let request_id = serde_json::json!(uuid::Uuid::new_v4().to_string());
+        let call = endpoint.client.json_rpc(method, params, request_id);
+        let value = match tokio::time::timeout(budget, call).await {
+            Ok(Ok(v)) => v,
+            Ok(Err(e)) => anyhow::bail!("{}: {}", method, e),
+            Err(_) => anyhow::bail!("{}: timed out after {}s", method, budget.as_secs()),
+        };
+        serde_json::from_value::<T>(value).with_context(|| format!("deserialize {method} response"))
+    }
+
+    /// Two-step probe (`getMasterchainInfo` → `getBlockHeader`) that yields the tip's `gen_utime`
+    /// and stores the snapshot. Both calls must succeed; partial success leaves the cache
+    /// untouched so it never reflects half-fresh state.
+    async fn refresh_endpoint_freshness(&self, idx: usize) -> anyhow::Result<()> {
+        let info: GetMasterchainInfoRes =
+            self.call_single_endpoint(idx, "getMasterchainInfo", serde_json::json!({})).await?;
+        let block_id_params =
+            serde_json::to_value(&info.last).context("serialize BlockIdExt for getBlockHeader")?;
+        let header: GetBlockHeaderRes =
+            self.call_single_endpoint(idx, "getBlockHeader", block_id_params).await?;
+
+        let now = self.clock.now();
+        let endpoint = &self.endpoints[idx];
+        endpoint.freshness.gen_utime.store(header.gen_utime, Ordering::Relaxed);
+        endpoint.freshness.observed_at.store(now, Ordering::Relaxed);
+        Ok(())
     }
 
     pub async fn get_config_param(&self, param_id: u32) -> anyhow::Result<ConfigParamEnum> {
@@ -312,12 +449,33 @@ impl ClientJsonRpc {
         let wallet_info = serde_json::from_value::<GetWalletInformationRes>(res)?;
         Ok(wallet_info)
     }
+
+    pub async fn get_masterchain_info(&self) -> anyhow::Result<GetMasterchainInfoRes> {
+        let res = self
+            .json_rpc("getMasterchainInfo", serde_json::json!({}))
+            .await
+            .context("getMasterchainInfo")?;
+        Ok(serde_json::from_value::<GetMasterchainInfoRes>(res)?)
+    }
+
+    pub async fn get_block_header(
+        &self,
+        block_id: &BlockIdExt,
+    ) -> anyhow::Result<GetBlockHeaderRes> {
+        let params = serde_json::to_value(block_id).context("serialize BlockIdExt")?;
+        let res = self.json_rpc("getBlockHeader", params).await.context("getBlockHeader")?;
+        Ok(serde_json::from_value::<GetBlockHeaderRes>(res)?)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{ClientJsonRpc, is_endpoints_unreachable};
-    use common::app_config::EndpointTimeouts;
+    use super::{ClientJsonRpc, is_endpoints_stale, is_endpoints_unreachable};
+    use base64::Engine;
+    use common::{
+        app_config::{EndpointTimeouts, FreshnessConfig},
+        clock::MockClock,
+    };
     use std::{
         sync::{
             Arc,
@@ -418,6 +576,7 @@ mod tests {
             vec![(bad_url, None), (good_url, None)],
             None,
             EndpointTimeouts::default(),
+            FreshnessConfig::disabled(),
         )
         .expect("client");
 
@@ -450,6 +609,7 @@ mod tests {
             vec![(first_url, None), (second_url, None)],
             None,
             EndpointTimeouts::default(),
+            FreshnessConfig::disabled(),
         )
         .expect("client");
 
@@ -480,6 +640,7 @@ mod tests {
             vec![(bad_1.clone(), None), (bad_2.clone(), None)],
             None,
             EndpointTimeouts::default(),
+            FreshnessConfig::disabled(),
         )
         .expect("client");
 
@@ -540,8 +701,13 @@ mod tests {
             request: Duration::from_millis(200),
         };
 
-        let client = ClientJsonRpc::connect_many(vec![(dead_url.clone(), None)], None, timeouts)
-            .expect("client");
+        let client = ClientJsonRpc::connect_many(
+            vec![(dead_url.clone(), None)],
+            None,
+            timeouts,
+            FreshnessConfig::disabled(),
+        )
+        .expect("client");
 
         let start = std::time::Instant::now();
         let err = client
@@ -578,6 +744,7 @@ mod tests {
             vec![(a_url.clone(), None), (b_url.clone(), None), (c_url.clone(), None)],
             None,
             timeouts,
+            FreshnessConfig::disabled(),
         )
         .expect("client");
 
@@ -601,5 +768,377 @@ mod tests {
         a_handle.abort();
         b_handle.abort();
         c_handle.abort();
+    }
+
+    // ---- Freshness probe tests ----
+
+    #[derive(Default)]
+    struct ProbeStats {
+        masterchain_info: AtomicUsize,
+        block_header: AtomicUsize,
+        other: AtomicUsize,
+    }
+
+    /// Spawn a mock server that accepts multiple connections and dispatches responses by the
+    /// `"method":...` substring in the request body. Returns the URL and an abort handle.
+    ///
+    /// - `getMasterchainInfo` → a fixed `last` BlockIdExt.
+    /// - `getBlockHeader` → header with the provided `gen_utime`.
+    /// - everything else → `{"from":"business"}`.
+    ///
+    /// Tests must avoid placing the probe method names into business `params` — the
+    /// dispatcher is substring-based and would misclassify (no business call uses
+    /// these method names today).
+    async fn spawn_freshness_server(
+        gen_utime: u32,
+        stats: Arc<ProbeStats>,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else { return };
+                let stats = stats.clone();
+                tokio::spawn(async move {
+                    let mut acc = Vec::with_capacity(4096);
+                    let mut buf = [0_u8; 4096];
+                    loop {
+                        let n = match socket.read(&mut buf).await {
+                            Ok(0) | Err(_) => break,
+                            Ok(n) => n,
+                        };
+                        acc.extend_from_slice(&buf[..n]);
+                        let s = std::str::from_utf8(&acc).unwrap_or("");
+                        if s.contains("\"method\"") {
+                            break;
+                        }
+                        if acc.len() > 8192 {
+                            break;
+                        }
+                    }
+                    let body_str = std::str::from_utf8(&acc).unwrap_or("");
+                    let zero_hash = base64::engine::general_purpose::STANDARD.encode([0u8; 32]);
+                    let result = if body_str.contains("\"getMasterchainInfo\"") {
+                        stats.masterchain_info.fetch_add(1, Ordering::Relaxed);
+                        serde_json::json!({
+                            "@type": "blocks.masterchainInfo",
+                            "last": {
+                                "@type": "ton.blockIdExt",
+                                "workchain": -1_i32,
+                                "shard": "-9223372036854775808",
+                                "seqno": 100_u64,
+                                "root_hash": zero_hash,
+                                "file_hash": zero_hash,
+                            }
+                        })
+                    } else if body_str.contains("\"getBlockHeader\"") {
+                        stats.block_header.fetch_add(1, Ordering::Relaxed);
+                        serde_json::json!({
+                            "@type": "blocks.header",
+                            "id": { "workchain": -1, "shard": "-9223372036854775808", "seqno": 100 },
+                            "gen_utime": gen_utime,
+                        })
+                    } else {
+                        stats.other.fetch_add(1, Ordering::Relaxed);
+                        serde_json::json!({"from": "business"})
+                    };
+
+                    let body = serde_json::json!({
+                        "ok": true,
+                        "jsonrpc": "2.0",
+                        "result": result,
+                        "id": "1"
+                    })
+                    .to_string();
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = socket.write_all(response.as_bytes()).await;
+                    let _ = socket.shutdown().await;
+                });
+            }
+        });
+        (format!("http://{}", addr), handle)
+    }
+
+    /// Both probe calls (`getMasterchainInfo`, `getBlockHeader`) return HTTP 500;
+    /// any other method gets the canned business response. Useful for testing how
+    /// `json_rpc` reacts when a probe cannot succeed against an endpoint.
+    async fn spawn_probe_failing_server(
+        stats: Arc<ProbeStats>,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else { return };
+                let stats = stats.clone();
+                tokio::spawn(async move {
+                    let mut acc = Vec::with_capacity(4096);
+                    let mut buf = [0_u8; 4096];
+                    loop {
+                        let n = match socket.read(&mut buf).await {
+                            Ok(0) | Err(_) => break,
+                            Ok(n) => n,
+                        };
+                        acc.extend_from_slice(&buf[..n]);
+                        if std::str::from_utf8(&acc).unwrap_or("").contains("\"method\"") {
+                            break;
+                        }
+                        if acc.len() > 8192 {
+                            break;
+                        }
+                    }
+                    let body_str = std::str::from_utf8(&acc).unwrap_or("");
+                    let is_probe = body_str.contains("\"getMasterchainInfo\"")
+                        || body_str.contains("\"getBlockHeader\"");
+                    if is_probe {
+                        if body_str.contains("\"getMasterchainInfo\"") {
+                            stats.masterchain_info.fetch_add(1, Ordering::Relaxed);
+                        } else {
+                            stats.block_header.fetch_add(1, Ordering::Relaxed);
+                        }
+                        let body = r#"{"ok":false,"error":"down"}"#;
+                        let response = format!(
+                            "HTTP/1.1 500 Internal Server Error\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                            body.len(),
+                            body
+                        );
+                        let _ = socket.write_all(response.as_bytes()).await;
+                    } else {
+                        stats.other.fetch_add(1, Ordering::Relaxed);
+                        let result = serde_json::json!({"from": "business"});
+                        let body = serde_json::json!({
+                            "ok": true,
+                            "jsonrpc": "2.0",
+                            "result": result,
+                            "id": "1"
+                        })
+                        .to_string();
+                        let response = format!(
+                            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                            body.len(),
+                            body
+                        );
+                        let _ = socket.write_all(response.as_bytes()).await;
+                    }
+                    let _ = socket.shutdown().await;
+                });
+            }
+        });
+        (format!("http://{}", addr), handle)
+    }
+
+    /// `MockClock` returning a wall-clock time consistent with the block's `gen_utime`
+    /// so freshness math is deterministic. `chain_now` is the simulated chain head time.
+    fn mock_clock_at(chain_now: u32) -> MockClock {
+        MockClock::new(u64::from(chain_now))
+    }
+
+    #[tokio::test]
+    async fn probe_updates_freshness_and_endpoint_serves_business_request() {
+        let stats = Arc::new(ProbeStats::default());
+        // gen_utime equal to the clock → 0s of lag → fresh.
+        let chain_now: u32 = 1_700_000_000;
+        let (url, handle) = spawn_freshness_server(chain_now, stats.clone()).await;
+
+        let mut client = ClientJsonRpc::connect_many(
+            vec![(url, None)],
+            None,
+            EndpointTimeouts::default(),
+            FreshnessConfig::default(),
+        )
+        .expect("client");
+        client.set_clock(Arc::new(mock_clock_at(chain_now)));
+
+        let resp = client
+            .json_rpc("getAddressInformation", serde_json::json!({"address":"x"}))
+            .await
+            .expect("business call should succeed");
+
+        assert_eq!(resp["from"], "business");
+        assert_eq!(stats.masterchain_info.load(Ordering::Relaxed), 1);
+        assert_eq!(stats.block_header.load(Ordering::Relaxed), 1);
+        assert_eq!(stats.other.load(Ordering::Relaxed), 1);
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn all_endpoints_stale_returns_dedicated_error() {
+        let s1 = Arc::new(ProbeStats::default());
+        let s2 = Arc::new(ProbeStats::default());
+        let chain_now: u32 = 1_700_000_000;
+        // gen_utime 5 minutes behind the clock → stale (default max_lag_secs=60).
+        let (u1, h1) = spawn_freshness_server(chain_now - 300, s1.clone()).await;
+        let (u2, h2) = spawn_freshness_server(chain_now - 300, s2.clone()).await;
+
+        let mut client = ClientJsonRpc::connect_many(
+            vec![(u1.clone(), None), (u2.clone(), None)],
+            None,
+            EndpointTimeouts::default(),
+            FreshnessConfig::default(),
+        )
+        .expect("client");
+        client.set_clock(Arc::new(mock_clock_at(chain_now)));
+
+        let err = client
+            .json_rpc("getAddressInformation", serde_json::json!({"address":"x"}))
+            .await
+            .expect_err("should fail with ENDPOINTS_STALE_TAG");
+
+        assert!(is_endpoints_stale(&err), "expected stale error: {err}");
+        assert!(!is_endpoints_unreachable(&err), "should NOT be unreachable: {err}");
+        let s = err.to_string();
+        assert!(s.contains("stale chain view"), "error should mention stale: {s}");
+
+        // Both endpoints were fully probed (both probe RPCs); no business calls reached either.
+        assert_eq!(s1.masterchain_info.load(Ordering::Relaxed), 1);
+        assert_eq!(s1.block_header.load(Ordering::Relaxed), 1);
+        assert_eq!(s2.masterchain_info.load(Ordering::Relaxed), 1);
+        assert_eq!(s2.block_header.load(Ordering::Relaxed), 1);
+        assert_eq!(s1.other.load(Ordering::Relaxed) + s2.other.load(Ordering::Relaxed), 0);
+
+        h1.abort();
+        h2.abort();
+    }
+
+    #[tokio::test]
+    async fn stale_endpoint_skipped_and_fresh_endpoint_used() {
+        let s_stale = Arc::new(ProbeStats::default());
+        let s_fresh = Arc::new(ProbeStats::default());
+        let chain_now: u32 = 1_700_000_000;
+        let (u_stale, h_stale) = spawn_freshness_server(chain_now - 300, s_stale.clone()).await;
+        let (u_fresh, h_fresh) = spawn_freshness_server(chain_now, s_fresh.clone()).await;
+
+        let mut client = ClientJsonRpc::connect_many(
+            vec![(u_stale.clone(), None), (u_fresh.clone(), None)],
+            None,
+            EndpointTimeouts::default(),
+            FreshnessConfig::default(),
+        )
+        .expect("client");
+        client.set_clock(Arc::new(mock_clock_at(chain_now)));
+
+        let resp = client
+            .json_rpc("getAddressInformation", serde_json::json!({"address":"x"}))
+            .await
+            .expect("fresh endpoint should serve the request");
+
+        assert_eq!(resp["from"], "business");
+        // Stale endpoint received a probe but no business call.
+        assert_eq!(s_stale.other.load(Ordering::Relaxed), 0);
+        // Fresh endpoint received a probe + the business call.
+        assert_eq!(s_fresh.other.load(Ordering::Relaxed), 1);
+
+        h_stale.abort();
+        h_fresh.abort();
+    }
+
+    #[tokio::test]
+    async fn lazy_probe_within_ttl_skips_reprobe() {
+        let stats = Arc::new(ProbeStats::default());
+        let chain_now: u32 = 1_700_000_000;
+        let (url, handle) = spawn_freshness_server(chain_now, stats.clone()).await;
+
+        let clock = mock_clock_at(chain_now);
+        let mut client = ClientJsonRpc::connect_many(
+            vec![(url, None)],
+            None,
+            EndpointTimeouts::default(),
+            FreshnessConfig::default(),
+        )
+        .expect("client");
+        client.set_clock(Arc::new(clock.clone()));
+
+        client
+            .json_rpc("getAddressInformation", serde_json::json!({"address":"x"}))
+            .await
+            .expect("first business call");
+        // Within TTL (default 30s).
+        clock.advance(10);
+        client
+            .json_rpc("getAddressInformation", serde_json::json!({"address":"x"}))
+            .await
+            .expect("second business call");
+
+        // Probe ran once, business calls ran twice.
+        assert_eq!(stats.masterchain_info.load(Ordering::Relaxed), 1);
+        assert_eq!(stats.block_header.load(Ordering::Relaxed), 1);
+        assert_eq!(stats.other.load(Ordering::Relaxed), 2);
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn lazy_probe_after_ttl_reprobes() {
+        let stats = Arc::new(ProbeStats::default());
+        let chain_now: u32 = 1_700_000_000;
+        let (url, handle) = spawn_freshness_server(chain_now, stats.clone()).await;
+
+        let clock = mock_clock_at(chain_now);
+        let mut client = ClientJsonRpc::connect_many(
+            vec![(url, None)],
+            None,
+            EndpointTimeouts::default(),
+            FreshnessConfig::default(),
+        )
+        .expect("client");
+        client.set_clock(Arc::new(clock.clone()));
+
+        client
+            .json_rpc("getAddressInformation", serde_json::json!({"address":"x"}))
+            .await
+            .expect("first business call");
+        // Beyond TTL (default 30s).
+        clock.advance(31);
+        client
+            .json_rpc("getAddressInformation", serde_json::json!({"address":"x"}))
+            .await
+            .expect("second business call");
+
+        assert_eq!(stats.masterchain_info.load(Ordering::Relaxed), 2);
+        assert_eq!(stats.block_header.load(Ordering::Relaxed), 2);
+        assert_eq!(stats.other.load(Ordering::Relaxed), 2);
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn probe_failure_skips_endpoint_and_fails_over() {
+        let s_bad = Arc::new(ProbeStats::default());
+        let s_good = Arc::new(ProbeStats::default());
+        let chain_now: u32 = 1_700_000_000;
+        let (u_bad, h_bad) = spawn_probe_failing_server(s_bad.clone()).await;
+        let (u_good, h_good) = spawn_freshness_server(chain_now, s_good.clone()).await;
+
+        let mut client = ClientJsonRpc::connect_many(
+            vec![(u_bad.clone(), None), (u_good.clone(), None)],
+            None,
+            EndpointTimeouts::default(),
+            FreshnessConfig::default(),
+        )
+        .expect("client");
+        client.set_clock(Arc::new(mock_clock_at(chain_now)));
+
+        let resp = client
+            .json_rpc("getAddressInformation", serde_json::json!({"address":"x"}))
+            .await
+            .expect("fail over to good endpoint");
+
+        assert_eq!(resp["from"], "business");
+        // Bad endpoint: probe attempted (500), no business call.
+        assert_eq!(s_bad.masterchain_info.load(Ordering::Relaxed), 1);
+        assert_eq!(s_bad.other.load(Ordering::Relaxed), 0);
+        // Good endpoint served probe + business call.
+        assert_eq!(s_good.masterchain_info.load(Ordering::Relaxed), 1);
+        assert_eq!(s_good.block_header.load(Ordering::Relaxed), 1);
+        assert_eq!(s_good.other.load(Ordering::Relaxed), 1);
+
+        h_bad.abort();
+        h_good.abort();
     }
 }

--- a/src/node-control/ton-http-api-client/src/v2/data_models.rs
+++ b/src/node-control/ton-http-api-client/src/v2/data_models.rs
@@ -198,6 +198,18 @@ impl Display for WalletType {
     }
 }
 
+/// Subset of the `getMasterchainInfo` response — only the `last` block id is captured.
+#[derive(serde::Deserialize, serde::Serialize)]
+pub struct GetMasterchainInfoRes {
+    pub last: BlockIdExt,
+}
+
+/// Subset of the `getBlockHeader` response — only `gen_utime` is captured.
+#[derive(serde::Deserialize, serde::Serialize)]
+pub struct GetBlockHeaderRes {
+    pub gen_utime: u32,
+}
+
 #[derive(Clone, serde::Deserialize, serde::Serialize)]
 pub struct GetWalletInformationRes {
     #[serde(rename = "@type")]


### PR DESCRIPTION
## Summary

- Adds a lazy per-endpoint freshness probe to `ClientJsonRpc`: before each request the client verifies the endpoint isn't lagging by reading its masterchain tip (`getMasterchainInfo` + `getBlockHeader`) and comparing the block's `gen_utime` against wall-clock time. Endpoints whose chain view exceeds `max_lag_secs` are skipped.
- When **every** endpoint is stale, `json_rpc` returns a dedicated error (`ENDPOINTS_STALE_TAG`, `is_endpoints_stale(err) == true`) instead of silently serving outdated data — the SMA-96 incident class.
- Probe is rate-limited per endpoint via `probe_interval_secs`; no extra RPC per business call once an endpoint is known fresh.
- New `FreshnessConfig` (`probe_interval_secs=30s`, `max_lag_secs=60s` by default) wired into `TonHttpApiConfig`; both knobs are hot-reloaded with the rest of the config file.
- `get_masterchain_info()` and `get_block_header(BlockIdExt)` exposed as typed public methods on `ClientJsonRpc` for general reuse (same shape as the existing `get_address_information` etc.).
- Behaviour-neutral for existing callers: tests that don't care about freshness opt out with `FreshnessConfig::disabled()`.

Depends on `Clock` infrastructure from #176 (SMA-98), already merged into the base branch.

Closes SMA-96.