### PR TITLE
fix(nodectl): drop @type from BlockIdExt serialization for getBlockHeader

### DIFF
--- a/src/node-control/ton-http-api-client/src/v2/data_models.rs
+++ b/src/node-control/ton-http-api-client/src/v2/data_models.rs
@@ -124,7 +124,7 @@ pub struct TransactionId {
 
 #[derive(serde::Deserialize, serde::Serialize)]
 pub struct BlockIdExt {
-    #[serde(rename = "@type")]
+    #[serde(rename = "@type", skip_serializing)]
     pub r#type: String,
     pub workchain: i32,
 

--- a/src/node-control/ton-http-api-client/src/v2/data_models.rs
+++ b/src/node-control/ton-http-api-client/src/v2/data_models.rs
@@ -246,3 +246,28 @@ mod account_state_tests {
         assert_eq!(s, "\"uninit\"");
     }
 }
+
+#[cfg(test)]
+mod block_id_ext_tests {
+    use super::BlockIdExt;
+
+    #[test]
+    fn serialize_omits_at_type_but_keeps_block_id_fields() {
+        let block = BlockIdExt {
+            r#type: "ton.blockIdExt".to_string(),
+            workchain: -1,
+            shard: i64::MIN,
+            seqno: 100,
+            root_hash: vec![0u8; 32],
+            file_hash: vec![1u8; 32],
+        };
+        let v = serde_json::to_value(&block).expect("serialize BlockIdExt");
+        let obj = v.as_object().expect("object");
+        assert!(!obj.contains_key("@type"), "@type must not be serialized: {v}");
+        assert_eq!(obj.get("workchain"), Some(&serde_json::json!(-1)));
+        assert_eq!(obj.get("shard"), Some(&serde_json::json!(i64::MIN.to_string())));
+        assert_eq!(obj.get("seqno"), Some(&serde_json::json!(100)));
+        assert!(obj.contains_key("root_hash"));
+        assert!(obj.contains_key("file_hash"));
+    }
+}


### PR DESCRIPTION
## Summary

Mainnet ton-http-api rejects `getBlockHeader` requests with `422 Unknown property '@type'` because `BlockIdExt` was serialized verbatim from the `getMasterchainInfo` response (which carries `@type`) into request params. Per toncenter OpenAPI, `getBlockHeader` only accepts `workchain`/`shard`/`seqno` (+ optional `root_hash`/`file_hash`); `@type` is a response-only TL-B marker.

This broke the freshness probe (`refresh_endpoint_freshness`) on mainnet, causing every endpoint to be marked unhealthy:

```
runner tick error: get-method active_election_id error: ... ton-http-api unreachable:
tried 1 endpoint(s): [https://toncenter.com/api/v2: freshness probe failed:
getBlockHeader: Client error 422: {"ok":false,"error":"failed to parse post request: Unknown property '@type'", ...}]
```

Fix: mark `BlockIdExt.@type` as `skip_serializing` — deserialization from API responses is unchanged, the field simply doesn't go out in request bodies. Covers both `refresh_endpoint_freshness` and the public `get_block_header` call.