### PR TITLE
fix(node-control): stabilize TONCore active pool selection within a cycle

### DIFF
--- a/src/node-control/CHANGELOG.md
+++ b/src/node-control/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Past-elections cache refreshed periodically** — the elections runner now refreshes its past-elections and pool-address caches on a TTL instead of only invalidating when the election round changes. Prevents a stale snapshot from a lagging RPC endpoint from persisting for an entire round and distorting frozen-stake accounting.
+- **Nominator Pool active slot stays the same for the whole election cycle** — for two-pool Nominator Pool setups, the router could switch to the idle sibling pool a few minutes after stake submission once the pool-address cache refreshed, so subsequent balance and stake-recovery lookups acted on the wrong pool. The active slot is now pinned to the cycle being serviced and stays consistent until the next election cycle.
+- **Nominator Pool: skip redundant validator-set update transactions** — the contracts task no longer sends `update_validator_set` to a Nominator Pool when the on-chain validator set has not changed since the last update. Removes a no-op masterchain transaction on every automation tick.
 
 ## [0.5.0] - 2026-05-18
 

--- a/src/node-control/contracts/src/nominator/ton_core_nominator_router.rs
+++ b/src/node-control/contracts/src/nominator/ton_core_nominator_router.rs
@@ -71,7 +71,9 @@ impl TonCoreNominatorRouter {
         {
             return Ok(pool.clone());
         }
-        anyhow::bail!("no one pool is ready");
+        anyhow::bail!(
+            "no pool ready: none matches stake_at={election_id} and none is idle/recoverable",
+        );
     }
 
     pub fn new(provider: Arc<dyn ContractProvider>, pools: [Option<MsgAddressInt>; 2]) -> Self {

--- a/src/node-control/contracts/src/nominator/ton_core_nominator_router.rs
+++ b/src/node-control/contracts/src/nominator/ton_core_nominator_router.rs
@@ -16,7 +16,10 @@ use super::{
 };
 use crate::{ContractProvider, SmartContract, TonWallet};
 use anyhow::Context;
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
 use ton_block::{Cell, MsgAddressInt, StateInit};
 
 /// TONCore nominator binding: two pool contracts (even/odd validation rounds).
@@ -25,24 +28,50 @@ use ton_block::{Cell, MsgAddressInt, StateInit};
 /// node; use [`NominatorWrapper::inner_pools`] to iterate both contracts (deploy, RPC).
 pub struct TonCoreNominatorRouter {
     pools: [Option<Arc<dyn NominatorWrapper>>; 2],
+    /// Current election id; pins active-slot selection to the cycle being serviced.
+    /// `0` means "not set" — falls back to legacy state-based selection (used by non-election
+    /// callers like the HTTP config handler that share the router via `Arc`). The election
+    /// runner short-circuits at `election_id == 0`, so `0` is never a real cycle id and the
+    /// sentinel is unambiguous.
+    current_election_id: AtomicU64,
 }
 
 impl TonCoreNominatorRouter {
+    /// Resolve the active slot for the current election cycle.
+    ///
+    /// Rules (applied in order):
+    /// 1. `election_id` set and one of the pools has `stake_at == election_id` → that pool.
+    ///    `pool.fc` writes `stake_at` immediately on `op::new_stake` (before the elector
+    ///    reply), so this match remains valid across the in-cycle `state` transitions
+    ///    (0→1→2): once the runner submits a bid, every subsequent call returns the same slot.
+    /// 2. Otherwise return the first pool that is either idle (`state == 0`) or has finished
+    ///    its previous cycle and is ready to be recovered (`state == 2 && vsc >= 2`). This
+    ///    branch is also the fallback for non-election callers (where `election_id` is unset).
+    /// 3. Neither rule matches → no pool is ready; error.
     async fn active_pool(&self) -> anyhow::Result<Arc<dyn NominatorWrapper>> {
-        // TONCore: pick the first pool that is not currently staking or is ready to recover stake.
+        let election_id = self.current_election_id.load(Ordering::Relaxed);
+
+        let mut entries: Vec<(Arc<dyn NominatorWrapper>, PoolData)> = Vec::with_capacity(2);
         for pool in self.pools.iter().flatten() {
             let data = pool.get_pool_data().await.context("get_pool_data failed")?;
-            if data.state == 0 // pool is not staking
-            // pool has sent stake (state=2) earlier and is ready to recover it (validator_set_changes_count >= 2)
-                || (data.state == 2 && data.validator_set_changes_count >= 2)
-            {
-                return Ok(pool.clone());
-            }
+            entries.push((pool.clone(), data));
         }
-        if self.pools.iter().any(|p| p.is_some()) {
-            anyhow::bail!("no one pool is ready");
+        if entries.is_empty() {
+            anyhow::bail!("no pools configured");
         }
-        anyhow::bail!("no pools configured")
+
+        if election_id != 0
+            && let Some((pool, _)) = entries.iter().find(|(_, d)| d.stake_at as u64 == election_id)
+        {
+            return Ok(pool.clone());
+        }
+        if let Some((pool, _)) = entries
+            .iter()
+            .find(|(_, d)| d.state == 0 || (d.state == 2 && d.validator_set_changes_count >= 2))
+        {
+            return Ok(pool.clone());
+        }
+        anyhow::bail!("no one pool is ready");
     }
 
     pub fn new(provider: Arc<dyn ContractProvider>, pools: [Option<MsgAddressInt>; 2]) -> Self {
@@ -52,12 +81,12 @@ impl TonCoreNominatorRouter {
                     as Arc<dyn NominatorWrapper>
             })
         });
-        Self { pools }
+        Self { pools, current_election_id: AtomicU64::new(0) }
     }
 
     /// Build a router from optional per-slot pool wrappers (e.g. from config).
     pub fn from_wrappers(pools: [Option<Arc<dyn NominatorWrapper>>; 2]) -> Self {
-        Self { pools }
+        Self { pools, current_election_id: AtomicU64::new(0) }
     }
 }
 
@@ -74,6 +103,10 @@ impl SmartContract for TonCoreNominatorRouter {
 
 #[async_trait::async_trait]
 impl NominatorWrapper for TonCoreNominatorRouter {
+    fn set_election_id(&self, election_id: u64) {
+        self.current_election_id.store(election_id, Ordering::Relaxed);
+    }
+
     fn pool_kind(&self) -> PoolKind {
         PoolKind::TONCore
     }

--- a/src/node-control/contracts/src/nominator/wrapper.rs
+++ b/src/node-control/contracts/src/nominator/wrapper.rs
@@ -33,6 +33,12 @@ pub enum PoolKind {
 /// vec (the pool itself is the only physical contract).
 #[async_trait::async_trait]
 pub trait NominatorWrapper: SmartContract + Send + Sync {
+    /// Set the current election cycle id so multi-pool routers (TONCore) can stably resolve
+    /// the active slot for the cycle. Single-pool wrappers ignore this. Must be called by the
+    /// client code at the start of each new elections before any other operation that depends on
+    /// active-pool resolution; otherwise [`TonCoreNominatorRouter`](crate::nominator::TonCoreNominatorRouter)
+    /// will fail with an explicit error rather than silently picking a slot.
+    fn set_election_id(&self, _election_id: u64) {}
     /// Get the owner and validator addresses stored in the contract
     async fn get_roles(&self) -> anyhow::Result<NominatorRoles>;
     /// Get pool data (parsed persistent storage of nominator)

--- a/src/node-control/contracts/src/nominator/wrapper.rs
+++ b/src/node-control/contracts/src/nominator/wrapper.rs
@@ -34,10 +34,10 @@ pub enum PoolKind {
 #[async_trait::async_trait]
 pub trait NominatorWrapper: SmartContract + Send + Sync {
     /// Set the current election cycle id so multi-pool routers (TONCore) can stably resolve
-    /// the active slot for the cycle. Single-pool wrappers ignore this. Must be called by the
-    /// client code at the start of each new elections before any other operation that depends on
-    /// active-pool resolution; otherwise [`TonCoreNominatorRouter`](crate::nominator::TonCoreNominatorRouter)
-    /// will fail with an explicit error rather than silently picking a slot.
+    /// the active slot for the cycle. SNP wrappers ignore this.
+    ///
+    /// Pass `0` (or never call this) to release the pin: the router then falls back to legacy
+    /// state-based selection.
     fn set_election_id(&self, _election_id: u64) {}
     /// Get the owner and validator addresses stored in the contract
     async fn get_roles(&self) -> anyhow::Result<NominatorRoles>;

--- a/src/node-control/service/src/elections/runner.rs
+++ b/src/node-control/service/src/elections/runner.rs
@@ -535,6 +535,13 @@ impl ElectionRunner {
 
         let mut skip_tick_nodes = vec![];
 
+        // Pin Nominator Pool to the current election cycle BEFORE any operation.
+        for node in self.nodes.values() {
+            if let Some(pool) = &node.pool {
+                pool.set_election_id(election_id);
+            }
+        }
+
         let now_ts = self.clock.now();
         let cache_expired = self.cache_refresh_secs > 0
             && now_ts.saturating_sub(self.cache_refreshed_at) >= self.cache_refresh_secs;

--- a/src/node-control/service/src/elections/runner.rs
+++ b/src/node-control/service/src/elections/runner.rs
@@ -498,6 +498,13 @@ impl ElectionRunner {
         if election_id == 0 {
             self.snapshot_cache.last_elections_status = ElectionsStatus::Closed;
             tracing::info!("no active elections");
+            // Release the cycle pin on all pool routers — non-election callers that share the
+            // router via `Arc` should fall back to legacy state-based selection between cycles.
+            for node in self.nodes.values() {
+                if let Some(pool) = &node.pool {
+                    pool.set_election_id(0);
+                }
+            }
             return Ok(());
         }
         tracing::info!(

--- a/src/node-control/service/src/elections/runner_tests.rs
+++ b/src/node-control/service/src/elections/runner_tests.rs
@@ -2862,7 +2862,7 @@ async fn test_toncore_nominator_both_pools_busy_skips_elections() {
 
     let mut runner = harness.build(node_id).await;
     let result = runner.run().await;
-    // Both pools busy → router's address() returns "no one pool is ready".
+    // Both pools busy → router's address() returns "no pool ready".
     // Node is excluded from the current tick; run() still succeeds.
     result.expect("run() should succeed — busy node is just skipped");
     assert_eq!(runner.past_elections_cache_id, ELECTION_ID);

--- a/src/node-control/service/src/elections/runner_tests.rs
+++ b/src/node-control/service/src/elections/runner_tests.rs
@@ -2871,6 +2871,57 @@ async fn test_toncore_nominator_both_pools_busy_skips_elections() {
     assert!(!node.stake_accepted);
 }
 
+/// Regression: once a pool has bid for the current cycle (`stake_at == election_id`), the
+/// router must keep returning that pool even after its `state` transitions away from `0`.
+/// Under the previous rule (`state == 0 || (state == 2 && vsc >= 2)`) the router would
+/// switch to the idle slot mid-cycle as soon as the cache was refreshed by the TTL.
+#[tokio::test]
+async fn test_toncore_nominator_active_slot_stable_after_stake_submission() {
+    let node_id = "node-1";
+    let mut harness = TestHarness::new().with_toncore_nominator_pair();
+
+    setup_default_elector(&mut harness.elector_mock, ELECTION_ID, 0);
+    setup_wallet(&mut harness.wallet_mock);
+    harness.wallet_mock.expect_message().returning(|_dest, _value, _payload| Ok(dummy_cell()));
+
+    let (p0, p1) = harness.toncore_nominator_mocks.as_mut().unwrap();
+
+    // pool[0]: just submitted for the current cycle. state=2 (accepted), stake_at=ELECTION_ID.
+    // Under the old rule this pool would be skipped (state==2 && vsc==0 fails the second arm),
+    // and pool[1] (state==0) would be chosen instead — switching slots mid-cycle.
+    p0.expect_address().returning(|| Ok(pool_address()));
+    p0.expect_get_pool_data().returning(|| {
+        Ok(PoolData { state: 2, stake_at: ELECTION_ID as u32, ..Default::default() })
+    });
+    p0.expect_storage_reserve().returning(|| TONCORE_STORAGE_RESERVE);
+    p0.expect_pool_kind().returning(|| PoolKind::TONCore);
+    p0.expect_has_withdraw_requests().returning(|| Ok(false));
+
+    setup_toncore_nominator_slot(p1, pool_address_1(), 0);
+
+    let pool0_hex = hex::encode(POOL_ADDR);
+    harness.provider_mock.expect_account().returning(move |address| {
+        if address.contains(&pool0_hex) {
+            Ok(fake_account(POOL_BALANCE))
+        } else {
+            Ok(fake_account(WALLET_BALANCE))
+        }
+    });
+    setup_default_provider_without_account(&mut harness.provider_mock, WALLET_BALANCE);
+
+    let mut runner = harness.build(node_id).await;
+    let result = runner.run().await;
+    assert!(result.is_ok(), "run() failed: {:?}", result.err());
+
+    let node = runner.nodes.get(node_id).unwrap();
+    // Cached address must still point at pool[0] — the slot that owns the current cycle.
+    assert_eq!(
+        node.pool_addr_cache.as_ref().map(|a| a.to_string()),
+        Some(pool_address().to_string()),
+        "router must keep returning the cycle-owning slot after state goes 0→2"
+    );
+}
+
 #[tokio::test]
 async fn test_toncore_nominator_recover_stake_uses_cached_pool_address() {
     let node_id = "node-1";


### PR DESCRIPTION
## Problem

`TonCoreNominatorRouter::active_pool` selected a slot based on transient pool state (`state == 0 || (state == 2 && vsc >= 2)`). The selection flipped mid-cycle as the active pool's `state` moved through 0→1→2 after a stake submission. With the runner's `pool_addr_cache` invalidated by the TTL refresh, this caused `pool_addr_cache` to point at the wrong slot ~5 minutes into the cycle, and downstream operations (`stake_balance`, snapshot, recover address) acted on the wrong pool.

## Fix

Stable per-cycle selection driven by `stake_at`. `pool.fc` writes `stake_at` immediately on `op::new_stake` (verified against the upstream contract source), so once the runner submits a bid the rule keeps returning the same slot regardless of subsequent `state` transitions.

- `NominatorWrapper::set_election_id` — new trait method with no-op default (single-pool wrappers ignore it).
- `TonCoreNominatorRouter` stores the current election id in an `AtomicU64` and resolves `active_pool` via:
  1. pool whose `stake_at == election_id` → that pool;
  2. otherwise legacy state-based selection (`state == 0` or `state == 2 && vsc >= 2`).
- `ElectionRunner::run` pins each node's router to the current cycle at the start of each tick, before any pool operation.
- `election_id == 0` (sentinel for "not set") routes through the legacy branch so non-election callers (`contracts_task`, HTTP config handlers) that share the router via `Arc` keep working without code changes.

## Test

Added `test_toncore_nominator_active_slot_stable_after_stake_submission` — a pool with `state=2, stake_at=ELECTION_ID` and a sibling with `state=0` must still resolve to the cycle-owning slot. Under the previous rule the router would have switched to the idle sibling.