### PR TITLE
feat(grafana): add cumulative collator successes graph

### DIFF
--- a/grafana/src/index.ts
+++ b/grafana/src/index.ts
@@ -55,6 +55,7 @@ const builder = new DashboardBuilder("TON Node Overview")
 
   // Validation & Collation
   .withRow(new RowBuilder("Validation & Collation"))
+  .withPanel(validation.collatorSuccessesTotal().span(12).height(8))
   .withPanel(validation.activeValidatorsCollators().span(12).height(8))
   .withPanel(validation.validationResults().span(12).height(8))
   .withPanel(validation.collationDuration().span(12).height(8))

--- a/grafana/src/validation.ts
+++ b/grafana/src/validation.ts
@@ -9,7 +9,7 @@ export const collatorSuccessesTotal = (): TimeseriesBuilder =>
     .decimals(0)
     .withTarget(
       promQuery(
-        `max by(node_id) (ton_node_collator_successes_total{${F}})`,
+        `sum by(node_id) (ton_node_collator_successes_total{${F}})`,
         "{{node_id}}",
       ),
     );

--- a/grafana/src/validation.ts
+++ b/grafana/src/validation.ts
@@ -3,6 +3,17 @@ import { PanelBuilder as TimeseriesBuilder } from "@grafana/grafana-foundation-s
 import * as units from "@grafana/grafana-foundation-sdk/units";
 import { defaultTimeseries, promQuery, histogramP, F } from "./common";
 
+export const collatorSuccessesTotal = (): TimeseriesBuilder =>
+  defaultTimeseries()
+    .title("Successful Collations (total)")
+    .decimals(0)
+    .withTarget(
+      promQuery(
+        `max by(node_id) (ton_node_collator_successes_total{${F}})`,
+        "{{node_id}}",
+      ),
+    );
+
 export const activeValidatorsCollators = (): TimeseriesBuilder =>
   defaultTimeseries()
     .title("Active Validators & Collators")


### PR DESCRIPTION
**Add cumulative collator successes graph**

Adds a **"Successful Collations (total)"** timeseries panel to the *Validation & Collation* row of the TON Node Overview dashboard, plotting `ton_node_collator_successes_total` per node.