### PR TITLE
fix(simplex): reject empty/zero-weight validator set in repair notar verification

### DIFF
--- a/src/node/simplex/src/receiver.rs
+++ b/src/node/simplex/src/receiver.rs
@@ -2608,12 +2608,23 @@ impl ReceiverImpl {
         let raw_vote_bytes = crate::utils::serialize_unsigned_vote(&unsigned_vote);
         let signed = crate::utils::create_data_to_sign(session_id, &raw_vote_bytes);
 
+        // Fail-closed against a degenerate validator set: `threshold_66(0) == 0`
+        // would make the `voted_weight < threshold` quorum check below evaluate
+        // `0 < 0 == false`, accepting a notar response that carries no signatures.
+        // A real session always has a non-empty set with positive total weight,
+        // so reject these shapes outright to keep this signature gate sound.
         let num_validators = sources.len();
+        if num_validators == 0 {
+            return Err("empty validator set".to_string());
+        }
         let mut voted = vec![false; num_validators];
         let mut total_weight: ValidatorWeight = 0;
         let mut voted_weight: ValidatorWeight = 0;
         for s in sources {
             total_weight = total_weight.saturating_add(s.weight);
+        }
+        if total_weight == 0 {
+            return Err("zero total validator weight".to_string());
         }
         let threshold = crate::utils::threshold_66(total_weight);
 

--- a/src/node/simplex/src/tests/test_candidate_resolver.rs
+++ b/src/node/simplex/src/tests/test_candidate_resolver.rs
@@ -1022,6 +1022,58 @@ fn test_validate_repair_notar_signature_set_rejects_insufficient_weight() {
     assert!(err.contains("insufficient weight"), "unexpected error: {err}");
 }
 
+/// An empty validator set must be rejected before the quorum check. Without
+/// this guard `threshold_66(0) == 0` would make the `voted_weight < threshold`
+/// test evaluate `0 < 0 == false`, wrongly accepting a signature-less response.
+#[test]
+fn test_validate_repair_notar_signature_set_rejects_empty_validator_set() {
+    let (session_id, sources, _keys) = build_repair_validator_set(0, 100);
+    assert!(sources.is_empty());
+    let slot = SlotIndex::new(19);
+    let block_hash = UInt256::from_slice(&[0xDD; 32]);
+    let vote = NotarizeVote { slot, block_hash: block_hash.clone() };
+    let notar_bytes = build_notar_signature_set_bytes(&session_id, &vote, &[]);
+
+    let err = super::ReceiverImpl::validate_repair_notar_signature_set(
+        &session_id,
+        &sources,
+        1 << 24,
+        slot,
+        &block_hash,
+        &notar_bytes,
+    )
+    .expect_err("empty validator set must be rejected");
+    assert!(err.contains("empty validator set"), "unexpected error: {err}");
+}
+
+/// A validator set whose total weight is zero must be rejected before the
+/// quorum check for the same `threshold_66(0) == 0` reason, even when the
+/// response carries otherwise well-formed signatures.
+#[test]
+fn test_validate_repair_notar_signature_set_rejects_zero_total_weight() {
+    let (session_id, sources, keys) = build_repair_validator_set(4, 0);
+    let slot = SlotIndex::new(20);
+    let block_hash = UInt256::from_slice(&[0xEE; 32]);
+    let vote = NotarizeVote { slot, block_hash: block_hash.clone() };
+
+    // Real signatures from 3 of 4 validators: only the zero total weight makes
+    // this degenerate, proving the guard (not a signature failure) rejects it.
+    let signing: Vec<(u32, &crate::PrivateKey)> =
+        (0..3u32).map(|i| (i, &keys[i as usize])).collect();
+    let notar_bytes = build_notar_signature_set_bytes(&session_id, &vote, &signing);
+
+    let err = super::ReceiverImpl::validate_repair_notar_signature_set(
+        &session_id,
+        &sources,
+        1 << 24,
+        slot,
+        &block_hash,
+        &notar_bytes,
+    )
+    .expect_err("zero total validator weight must be rejected");
+    assert!(err.contains("zero total validator weight"), "unexpected error: {err}");
+}
+
 /// When the notar set is signed for a different `(slot, block_hash)` than the
 /// receiver requested, signature verification cryptographically rejects it
 /// because the `dataToSign` payload binds the session id and the unsigned


### PR DESCRIPTION
## Summary

Addresses the Copilot review comment on #210. `ReceiverImpl::validate_repair_notar_signature_set` derived its quorum bar as `threshold_66(total_weight)`, and `threshold_66(0) == 0`, so the gate `voted_weight < threshold` evaluated `0 < 0 == false` and **accepted a signature-less `VoteSignatureSet`** whenever the validator set was empty or summed to zero weight.

This is **defense-in-depth**: a real session always carries a non-empty validator set with positive total weight, so the hole is not reachable in production. But this is a signature-verification gate where fail-closed is the right default, and it is the *one* quorum check that recomputes weight from a passed-in `sources` slice rather than the canonical `SessionDescription`.

> Base is `simplex` (the #210 head) rather than `master`, because the repair-channel validation function is introduced by #210 and is not yet on public `master`. Merge this into `simplex` (or fold into #210) before #210 lands on `master`.

## Changes

- `src/node/simplex/src/receiver.rs`: reject an empty validator set and zero total weight before the quorum check.
- `src/node/simplex/src/tests/test_candidate_resolver.rs`: add `test_validate_repair_notar_signature_set_rejects_empty_validator_set` and `..._rejects_zero_total_weight` regressions.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo test -p simplex --lib validate_repair_notar_signature_set` — **10 passed, 0 failed** (8 existing + 2 new), validated on the byte-identical internal mirror.

Internal counterpart: RSquad/ton-node#1000.