### PR TITLE
release/nodectl:v0.6.0

### DIFF
--- a/helm/nodectl/CHANGELOG.md
+++ b/helm/nodectl/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the nodectl Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 Versions follow the Helm chart release tags (e.g. `helm/nodectl/v0.1.0`).
 
+## [0.3.2] - 2026-06-19
+
+appVersion: `v0.6.0`
+
+### Changed
+
+- Default image updated to nodectl `v0.6.0`
+
 ## [0.3.1] - 2026-05-25
 
 appVersion: `v0.5.1`

--- a/helm/nodectl/Chart.yaml
+++ b/helm/nodectl/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: nodectl
 description: TON Node Control Tool — validator elections, voting, and monitoring
 type: application
-version: 0.3.1
-appVersion: "v0.5.1"
+version: 0.3.2
+appVersion: "v0.6.0"
 
 sources:
   - https://github.com/rsquad/ton-rust-node

--- a/helm/nodectl/values.yaml
+++ b/helm/nodectl/values.yaml
@@ -12,7 +12,7 @@ replicas: 1
 ##
 image:
   repository: ghcr.io/rsquad/ton-rust-node/nodectl
-  tag: "v0.5.1"
+  tag: "v0.6.0"
   pullPolicy: IfNotPresent
 
 ## @param imagePullSecrets [array] Registry pull secrets for private container images

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "adnl",
  "anyhow",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "adnl",
  "anyhow",
@@ -994,7 +994,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "contracts"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "control-client"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "adnl",
  "anyhow",
@@ -3309,7 +3309,7 @@ dependencies = [
 
 [[package]]
 name = "nodectl"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap 4.6.0",
@@ -4923,7 +4923,7 @@ dependencies = [
 
 [[package]]
 name = "service"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "adnl",
  "anyhow",
@@ -5634,7 +5634,7 @@ dependencies = [
 
 [[package]]
 name = "ton-http-api-client"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src/node-control/CHANGELOG.md
+++ b/src/node-control/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-06-19
+
+### Added
+
+- **Audit log** — a structured, append-only JSONL log of domain events (elections, REST config mutations, authentication, service lifecycle), written to `./logs/audit.jsonl` separately from the tracing service log. Each event carries a UUID v7 id, RFC3339 timestamp, outcome, dotted `event_type`, and `actor`/`target`. Includes size-based rotation (default 100 MiB × 10 files), batched writes with optional `fsync`, an in-memory ring buffer feeding the REST read path, and client-IP PII controls. Configured under a new `audit_log` section (read at startup); `0600` file mode on Unix. Recent elections events are surfaced in `GET /v1/elections` as `recent_events`. See `docs/audit-log.md`.
+
+### Fixed
+
+- **Nominator Pool: out-of-gas when processing withdraw requests** — fixed gas calculation so the process-withdraw-requests (op 2) message covers large withdraw-stake-request batches.
+
 ## [0.5.1] - 2026-05-25
 
 ### Added

--- a/src/node-control/commands/Cargo.toml
+++ b/src/node-control/commands/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "commands"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 license = 'GPL-3.0'
 

--- a/src/node-control/common/Cargo.toml
+++ b/src/node-control/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "common"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 license = 'GPL-3.0'
 

--- a/src/node-control/contracts/Cargo.toml
+++ b/src/node-control/contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contracts"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 license = 'GPL-3.0'
 

--- a/src/node-control/control-client/Cargo.toml
+++ b/src/node-control/control-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "control-client"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 license = 'GPL-3.0'
 

--- a/src/node-control/nodectl/Cargo.toml
+++ b/src/node-control/nodectl/Cargo.toml
@@ -2,7 +2,7 @@
 build = '../../common/build/build.rs'
 name = "nodectl"
 description = "Tool for managing Rust TON node"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 license = 'GPL-3.0'
 

--- a/src/node-control/service/Cargo.toml
+++ b/src/node-control/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 license = 'GPL-3.0'
 

--- a/src/node-control/ton-http-api-client/Cargo.toml
+++ b/src/node-control/ton-http-api-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ton-http-api-client"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 license = 'GPL-3.0'
 


### PR DESCRIPTION
Image: `ghcr.io/rsquad/ton-rust-node/nodectl:v0.6.0`

Bumps all node-control crates to v0.6.0, adds the app changelog entry, and bumps the Helm chart to 0.3.2 (appVersion `v0.6.0`).

### Added

- **Audit log** — a structured, append-only JSONL log of domain events (elections, REST config mutations, authentication, service lifecycle), written to `./logs/audit.jsonl` separately from the tracing service log. Each event carries a UUID v7 id, RFC3339 timestamp, outcome, dotted `event_type`, and `actor`/`target`. Includes size-based rotation (default 100 MiB × 10 files), batched writes with optional `fsync`, an in-memory ring buffer feeding the REST read path, and client-IP PII controls. Configured under a new `audit_log` section (read at startup); `0600` file mode on Unix. Recent elections events are surfaced in `GET /v1/elections` as `recent_events`. See `docs/audit-log.md`.

### Fixed

- **Nominator Pool: out-of-gas when processing withdraw requests** — fixed gas calculation so the process-withdraw-requests (op 2) message covers large withdraw-stake-request batches.

### Helm chart (0.3.2)

- Default image updated to nodectl `v0.6.0`